### PR TITLE
OCM-5022: Add support for creating cluster with shared VPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ TF_LOG=INFO
 # Don't remove this target
 verify:
 	@for d in examples/*; do \
-		echo "!! Validating $$d !!" && cd $$d && terraform init && terraform validate && cd - ;\
+		echo "!! Validating $$d !!" && cd $$d && rm -rf .terraform .terraform.lock.hcl && terraform init && terraform validate && cd - ;\
 	done
 
 .PHONY: tf-init

--- a/examples/rosa-classic-public-with-byo-vpc-byo-iam-byo-oidc/versions.tf
+++ b/examples/rosa-classic-public-with-byo-vpc-byo-iam-byo-oidc/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 5.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/examples/rosa-classic-public-with-byo-vpc/versions.tf
+++ b/examples/rosa-classic-public-with-byo-vpc/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 5.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/examples/rosa-classic-public-with-idp-machine-pools/versions.tf
+++ b/examples/rosa-classic-public-with-idp-machine-pools/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 5.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/examples/rosa-classic-public-with-shared-vpc/main.tf
+++ b/examples/rosa-classic-public-with-shared-vpc/main.tf
@@ -109,9 +109,14 @@ module "rosa_cluster_classic" {
   oidc_config_id               = module.oidc_provider.oidc_config_id
   aws_subnet_ids               = module.shared-vpc-policy-and-hosted-zone.shared_subnets
   multi_az                     = true
-  admin_credentials            = { username = "admin1", password = "123456!qwertyU" }
+  admin_credentials            = { username = "kubeadmin", password = random_password.password.result }
   compute_machine_type         = var.machine_type
   base_dns_domain              = rhcs_dns_domain.dns_domain.id
   private_hosted_zone_id       = module.shared-vpc-policy-and-hosted-zone.hosted_zone_id
   private_hosted_zone_role_arn = module.shared-vpc-policy-and-hosted-zone.shared_role
+}
+
+resource "random_password" "password" {
+  length  = 14
+  special = true
 }

--- a/examples/rosa-classic-public-with-shared-vpc/main.tf
+++ b/examples/rosa-classic-public-with-shared-vpc/main.tf
@@ -1,0 +1,117 @@
+provider "aws" {
+  alias = "shared-vpc"
+
+  access_key = var.shared_vpc_aws_key
+  secret_key = var.shared_vpc_aws_secret
+  region     = var.shared_vpc_aws_region
+}
+
+############################
+# VPC
+############################
+module "vpc" {
+  source = "../../modules/vpc"
+
+  providers = {
+    aws = aws.shared-vpc
+  }
+
+  name_prefix  = var.cluster_name
+  subnet_count = var.replicas
+}
+
+locals {
+  account_role_prefix  = var.account_role_prefix != null ? var.account_role_prefix : "${var.cluster_name}-account"
+  shared_vpc_role_name = var.shared_vpc_role_name != null ? var.shared_vpc_role_name : "${var.cluster_name}-shared-vpc-role"
+  operator_role_prefix = var.operator_role_prefix != null ? var.operator_role_prefix : "${var.cluster_name}-operator"
+}
+
+##############################################################
+# Account roles includes IAM roles and IAM policies
+##############################################################
+module "account_iam_resources" {
+  source = "../../modules/account-iam-resources"
+
+  account_role_prefix = local.account_role_prefix
+  openshift_version   = var.openshift_version
+}
+
+############################
+# operator policies
+############################
+module "operator_policies" {
+  source = "../../modules/operator-policies"
+
+  account_role_prefix = module.account_iam_resources.account_role_prefix
+  openshift_version   = module.account_iam_resources.openshift_version
+  shared_vpc_role_arn = "arn:aws:iam::${var.shared_vpc_aws_account}:role/${local.shared_vpc_role_name}"
+}
+
+############################
+# OIDC provider
+############################
+module "oidc_provider" {
+  source = "../../modules/oidc-provider"
+
+  managed = true
+}
+
+############################
+# operator roles
+############################
+module "operator_roles" {
+  source = "../../modules/operator-roles"
+
+  operator_role_prefix = local.operator_role_prefix
+
+  account_role_prefix = module.operator_policies.account_role_prefix
+  path                = module.account_iam_resources.path
+  oidc_endpoint_url   = module.oidc_provider.oidc_endpoint_url
+}
+
+resource "rhcs_dns_domain" "dns_domain" {}
+
+############################
+# shared-vpc-policy-and-hosted-zone
+############################
+data "aws_caller_identity" "current" {}
+
+module "shared-vpc-policy-and-hosted-zone" {
+  source = "../../modules/shared-vpc-policy-and-hosted-zone"
+
+  providers = {
+    aws = aws.shared-vpc
+  }
+
+  cluster_name              = var.cluster_name
+  target_aws_account        = data.aws_caller_identity.current.account_id
+  installer_role_arn        = module.account_iam_resources.account_roles_arn["Installer"]
+  ingress_operator_role_arn = module.operator_roles.operator_roles_arn["openshift-ingress-operator"]
+  subnets                   = concat(module.vpc.private_subnets, module.vpc.public_subnets)
+  hosted_zone_base_domain   = rhcs_dns_domain.dns_domain.id
+  vpc_id                    = module.vpc.vpc_id
+}
+
+############################
+# ROSA STS cluster
+############################
+module "rosa_cluster_classic" {
+  source = "../../modules/rosa-cluster-classic"
+
+  cluster_name                 = var.cluster_name
+  operator_role_prefix         = module.operator_roles.operator_role_prefix
+  openshift_version            = var.openshift_version
+  replicas                     = var.replicas
+  installer_role_arn           = module.account_iam_resources.account_roles_arn["Installer"]
+  support_role_arn             = module.account_iam_resources.account_roles_arn["Support"]
+  controlplane_role_arn        = module.account_iam_resources.account_roles_arn["ControlPlane"]
+  worker_role_arn              = module.account_iam_resources.account_roles_arn["Worker"]
+  oidc_config_id               = module.oidc_provider.oidc_config_id
+  aws_subnet_ids               = module.shared-vpc-policy-and-hosted-zone.shared_subnets
+  multi_az                     = true
+  admin_credentials            = { username = "admin1", password = "123456!qwertyU" }
+  compute_machine_type         = var.machine_type
+  base_dns_domain              = rhcs_dns_domain.dns_domain.id
+  private_hosted_zone_id       = module.shared-vpc-policy-and-hosted-zone.hosted_zone_id
+  private_hosted_zone_role_arn = module.shared-vpc-policy-and-hosted-zone.shared_role
+}

--- a/examples/rosa-classic-public-with-shared-vpc/variables.tf
+++ b/examples/rosa-classic-public-with-shared-vpc/variables.tf
@@ -1,0 +1,55 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "shared_vpc_aws_key" {
+  type = string
+}
+
+variable "shared_vpc_aws_secret" {
+  type = string
+}
+
+variable "shared_vpc_aws_region" {
+  type = string
+}
+
+variable "shared_vpc_aws_account" {
+  type = string
+}
+
+variable "shared_vpc_role_name" {
+  type    = string
+  default = null
+}
+
+variable "openshift_version" {
+  type    = string
+  default = "4.13.13"
+  validation {
+    condition     = can(regex("^[0-9]*[0-9]+.[0-9]*[0-9]+.[0-9]*[0-9]+$", var.openshift_version))
+    error_message = "openshift_version must be with structure <major>.<minor>.<patch> (for example 4.13.6)."
+  }
+}
+
+variable "account_role_prefix" {
+  type    = string
+  default = null
+}
+
+variable "operator_role_prefix" {
+  type    = string
+  default = null
+}
+
+variable "replicas" {
+  description = "The amount of the machine created in this machine pool."
+  type        = number
+  default     = 3
+}
+
+variable "machine_type" {
+  description = "Identifier of the machine type used by the nodes, for example `m5.xlarge`. Use the `rhcs_machine_types` data source to find the possible values."
+  type        = string
+  default     = "m5.xlarge"
+}

--- a/examples/rosa-classic-public-with-shared-vpc/versions.tf
+++ b/examples/rosa-classic-public-with-shared-vpc/versions.tf
@@ -10,5 +10,9 @@ terraform {
       version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/rosa-classic-public-with-shared-vpc/versions.tf
+++ b/examples/rosa-classic-public-with-shared-vpc/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    rhcs = {
+      version = ">= 1.5.0"
+      source  = "terraform-redhat/rhcs"
+    }
+  }
+}

--- a/examples/rosa-classic-public-with-unmanaged-oidc/versions.tf
+++ b/examples/rosa-classic-public-with-unmanaged-oidc/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/examples/rosa-classic-public/versions.tf
+++ b/examples/rosa-classic-public/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 5.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,9 @@ module "rosa_cluster_classic" {
   machine_cidr          = var.machine_cidr
   multi_az              = var.multi_az
   admin_credentials     = { username = "admin1", password = "123456!qwertyU" }
+  autoscaling_enabled   = var.autoscaling_enabled
+  min_replicas          = var.min_replicas
+  max_replicas          = var.max_replicas
 }
 
 ############################

--- a/modules/account-iam-resources/versions.tf
+++ b/modules/account-iam-resources/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.0"
     }
     rhcs = {
-      version = "1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/modules/idp/versions.tf
+++ b/modules/idp/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/modules/machine-pool/versions.tf
+++ b/modules/machine-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/modules/oidc-provider/variables.tf
+++ b/modules/oidc-provider/variables.tf
@@ -19,6 +19,7 @@ variable "issuer_url" {
 variable "installer_role_arn" {
   type        = string
   description = "STS Role ARN with get secrets permission"
+  default     = null
 }
 
 variable "cluster_id" {

--- a/modules/oidc-provider/versions.tf
+++ b/modules/oidc-provider/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/modules/operator-policies/outputs.tf
+++ b/modules/operator-policies/outputs.tf
@@ -1,3 +1,3 @@
 output "account_role_prefix" {
-  value = var.account_role_prefix
+  value = time_sleep.operator_policy_wait.triggers["account_role_prefix"]
 }

--- a/modules/operator-policies/versions.tf
+++ b/modules/operator-policies/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/modules/operator-policies/versions.tf
+++ b/modules/operator-policies/versions.tf
@@ -10,5 +10,9 @@ terraform {
       version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
   }
 }

--- a/modules/operator-roles/main.tf
+++ b/modules/operator-roles/main.tf
@@ -55,3 +55,13 @@ data "aws_iam_policy_document" "custom_trust_policy" {
     }
   }
 }
+
+# Wait 20 seconds after the operator role is created in order to avoid error in cluster create
+resource "time_sleep" "role_resources_propagation" {
+  create_duration = "20s"
+
+  triggers = {
+    operator_role_prefix = var.operator_role_prefix
+    operator_role_arns   = "[ ${join(", ", aws_iam_role.operator_role[*].arn)} ]"
+  }
+}

--- a/modules/operator-roles/outputs.tf
+++ b/modules/operator-roles/outputs.tf
@@ -1,5 +1,5 @@
 output "operator_role_prefix" {
-  value = var.operator_role_prefix
+  value = time_sleep.role_resources_propagation.triggers["operator_role_prefix"]
 }
 
 output "operator_roles_arn" {

--- a/modules/operator-roles/versions.tf
+++ b/modules/operator-roles/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/modules/operator-roles/versions.tf
+++ b/modules/operator-roles/versions.tf
@@ -10,5 +10,9 @@ terraform {
       version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
   }
 }

--- a/modules/rosa-cluster-classic/variables.tf
+++ b/modules/rosa-cluster-classic/variables.tf
@@ -99,3 +99,13 @@ variable "machine_cidr" {
   type    = string
   default = "10.0.0.0/16"
 }
+
+variable "private_hosted_zone_id" {
+  type    = string
+  default = null
+}
+
+variable "private_hosted_zone_role_arn" {
+  type    = string
+  default = null
+}

--- a/modules/rosa-cluster-classic/versions.tf
+++ b/modules/rosa-cluster-classic/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/modules/shared-vpc-policy-and-hosted-zone/main.tf
+++ b/modules/shared-vpc-policy-and-hosted-zone/main.tf
@@ -1,0 +1,119 @@
+locals {
+  name_prefix = var.name_prefix != null ? var.name_prefix : var.cluster_name
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "shared_vpc_role" {
+  name = "${local.name_prefix}-shared-vpc-role"
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/ResourceGroupsandTagEditorFullAccess"
+  ]
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          AWS = [
+            var.ingress_operator_role_arn,
+            var.installer_role_arn
+          ]
+        }
+      }
+    ]
+  })
+  description = "Role that will be assumed from the Target AWS account where the cluster resides"
+  lifecycle {
+    ignore_changes = [managed_policy_arns]
+  }
+}
+
+resource "aws_iam_policy" "shared_vpc_policy" {
+  name = "${local.name_prefix}-shared-vpc-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "route53:GetHostedZone",
+          "route53:ChangeResourceRecordSets",
+          "route53:ChangeTagsForResource",
+          "route53:ListResourceRecordSets",
+          "route53:ListTagsForResource",
+          "route53:GetAccountLimit",
+          "route53:UpdateHostedZoneComment"
+        ]
+        Resource = "arn:aws:route53:::hostedzone/${aws_route53_zone.shared_vpc_hosted_zone.id}"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "route53:GetChange",
+          "route53:ListHostedZonesByName",
+          "route53:ListHostedZones",
+          "tag:GetResources",
+          "tag:UntagResources"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "shared_vpc_role_policy_attachment" {
+  role       = aws_iam_role.shared_vpc_role.name
+  policy_arn = aws_iam_policy.shared_vpc_policy.arn
+}
+
+resource "aws_ram_resource_share" "shared_vpc_resource_share" {
+  name                      = "${local.name_prefix}-shared-vpc-resource-share"
+  allow_external_principals = true
+}
+
+resource "aws_ram_principal_association" "shared_vpc_resource_share" {
+  principal          = var.target_aws_account
+  resource_share_arn = aws_ram_resource_share.shared_vpc_resource_share.arn
+}
+
+locals {
+  resource_arn_prefix = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subnet/"
+}
+
+resource "aws_ram_resource_association" "shared_vpc_resource_association" {
+  count = length(var.subnets)
+
+  resource_arn       = "${local.resource_arn_prefix}${var.subnets[count.index]}"
+  resource_share_arn = aws_ram_resource_share.shared_vpc_resource_share.arn
+}
+
+resource "aws_route53_zone" "shared_vpc_hosted_zone" {
+  name = "${var.cluster_name}.${var.hosted_zone_base_domain}"
+
+  vpc {
+    vpc_id = var.vpc_id
+  }
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+# This resource is utilized to establish dependencies on all resources.
+# Some resources, such as aws_ram_principle_associasion, may not have their output utilized, but they are crucial for the cluster.
+# Hence, the creation of these resources must be finalized prior to the initiation of cluster creation, and they should not be removed before the cluster is destroyed.
+resource "time_sleep" "shared_resources_propagation" {
+  destroy_duration = "20s"
+  create_duration  = "20s"
+
+  triggers = {
+    shared_vpc_hosted_zone_id = aws_route53_zone.shared_vpc_hosted_zone.id
+    shared_vpc_role_arn       = aws_iam_role.shared_vpc_role.arn
+    resource_share_arn        = aws_ram_principal_association.shared_vpc_resource_share.resource_share_arn
+    policy_arn                = aws_iam_role_policy_attachment.shared_vpc_role_policy_attachment.policy_arn
+  }
+}

--- a/modules/shared-vpc-policy-and-hosted-zone/outputs.tf
+++ b/modules/shared-vpc-policy-and-hosted-zone/outputs.tf
@@ -1,0 +1,14 @@
+output "shared_role" {
+  description = "Shared Role"
+  value       = time_sleep.shared_resources_propagation.triggers["shared_vpc_role_arn"]
+}
+
+output "hosted_zone_id" {
+  description = "Hosted Zone ID"
+  value       = time_sleep.shared_resources_propagation.triggers["shared_vpc_hosted_zone_id"]
+}
+
+output "shared_subnets" {
+  description = "The Amazon Resource Names (ARN) of the resource share"
+  value       = [for resource_arn in aws_ram_resource_association.shared_vpc_resource_association[*].resource_arn : trimprefix(resource_arn, local.resource_arn_prefix)]
+}

--- a/modules/shared-vpc-policy-and-hosted-zone/variables.tf
+++ b/modules/shared-vpc-policy-and-hosted-zone/variables.tf
@@ -1,0 +1,38 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "name_prefix" {
+  type    = string
+  default = null
+}
+
+variable "target_aws_account" {
+  description = "Installer ARN from target account"
+  type        = string
+}
+
+variable "installer_role_arn" {
+  description = "Installer ARN from target account"
+  type        = string
+}
+
+variable "ingress_operator_role_arn" {
+  description = "Ingress Operator ARN from target account"
+  type        = string
+}
+
+variable "subnets" {
+  description = "Private subnet"
+  type        = list(string)
+}
+
+variable "hosted_zone_base_domain" {
+  description = "Base Domain"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The VPC ID"
+  type        = string
+}

--- a/modules/shared-vpc-policy-and-hosted-zone/versions.tf
+++ b/modules/shared-vpc-policy-and-hosted-zone/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
+  }
+}

--- a/modules/unmanaged-oidc-config/versions.tf
+++ b/modules/unmanaged-oidc-config/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -143,7 +143,7 @@ variable "vpc_private_subnets_ids" {
 variable "availability_zones" {
   description = "Create the vpc resources."
   type        = list(any)
-  default     = ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"]
+  default     = null
 }
 
 variable "multi_az" {

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.0"
     }
     rhcs = {
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
   }


### PR DESCRIPTION
This change includes adding the following:

* "shared-vpc-policy-and-hosted-zone" module - include all vpc policy and route53 actions
* "rosa-classic-public-with-shared-vpc" example

Fixes: [OCM-5022](https://issues.redhat.com/browse/OCM-5022)