### PR TITLE
Fix default availability zones in rosa cluster

### DIFF
--- a/modules/rosa-cluster-classic/variables.tf
+++ b/modules/rosa-cluster-classic/variables.tf
@@ -42,12 +42,12 @@ variable "oidc_config_id" {
 
 variable "aws_subnet_ids" {
   type    = list(string)
-  default = null
+  default = []
 }
 
 variable "availability_zones" {
   type    = list(string)
-  default = null
+  default = []
 }
 
 variable "aws_private_link" {

--- a/variables.tf
+++ b/variables.tf
@@ -143,7 +143,7 @@ variable "vpc_private_subnets_ids" {
 variable "availability_zones" {
   description = "Create the vpc resources."
   type        = list(any)
-  default     = null
+  default     = []
 }
 
 variable "multi_az" {


### PR DESCRIPTION
In case user doesn't provide availability zones or subnets IDs, use list of availability zones from AWS data source