### PR TITLE
OCM-4999: Arrange "VPC" sub-module variables, outputs and docs

### DIFF
--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -1,7 +1,67 @@
 # vpc
 
 ## Introduction
-TODO
+
+This Terraform sub-module is designed to facilitate the Bring Your Own VPC (BYO VPC) scenario for ROSA (Red Hat OpenShift Service on AWS) clusters. It enables users to provision and configure all necessary resources within an existing AWS VPC, ensuring compatibility and seamless integration with ROSA deployments. By leveraging this module, users can efficiently set up their own VPC environment, complete with networking components such as subnets, route tables, internet gateways, NAT gateways, and security groups, tailored specifically for ROSA cluster requirements. This flexibility allows for a smooth transition for users who prefer to utilize their own VPC infrastructure while leveraging the capabilities of ROSA on AWS.
 
 <!-- BEGIN_AUTOMATED_TF_DOCS_BLOCK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.23.1 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_eip.eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_internet_gateway.internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.public_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_route.ipv4_egress_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.ipv6_egress_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.private_nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route_table.private_route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table.public_route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table_association.private_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_subnet.private_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.public_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint_route_table_association.private_vpc_endpoint_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_route_table_association) | resource |
+| [time_sleep.vpc_resources_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | User-defined prefix for all generated AWS resources of this VPC | `string` | n/a | yes |
+| <a name="input_subnet_count"></a> [subnet\_count](#input\_subnet\_count) | The number of public/private subnet pairs to make. | `number` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | AWS tags to be applied to generated AWS resources of this VPC. | `map(string)` | `null` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | n/a | `string` | `"10.0.0.0/16"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_availability_zones"></a> [availability\_zones](#output\_availability\_zones) | List of the Availability Zone names used for the VPC creation |
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of private subnets created this this AWS VPC |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | List of public subnets created this this AWS VPC |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The unique ID of the VPC |
 <!-- END_AUTOMATED_TF_DOCS_BLOCK -->

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,4 +1,8 @@
-resource "aws_vpc" "site" {
+locals {
+  tags = var.tags == null ? {} : var.tags
+}
+
+resource "aws_vpc" "vpc" {
   cidr_block           = var.vpc_cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
@@ -6,7 +10,7 @@ resource "aws_vpc" "site" {
     {
       "Name" = "${var.name_prefix}-vpc"
     },
-    var.tags,
+    local.tags,
   )
   lifecycle {
     ignore_changes = [tags]
@@ -14,55 +18,54 @@ resource "aws_vpc" "site" {
 }
 
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id       = aws_vpc.site.id
+  vpc_id       = aws_vpc.vpc.id
   service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
 }
 
-resource "aws_subnet" "public" {
+resource "aws_subnet" "public_subnet" {
   count = var.subnet_count
 
-  vpc_id            = aws_vpc.site.id
+  vpc_id            = aws_vpc.vpc.id
   cidr_block        = cidrsubnet(var.vpc_cidr, var.subnet_count * 2, count.index)
   availability_zone = data.aws_availability_zones.available.names[count.index % length(data.aws_availability_zones.available.names)]
   tags = merge(
     {
       "Name" = join("-", [var.name_prefix, "subnet", "public${count.index + 1}", data.aws_availability_zones.available.names[count.index % length(data.aws_availability_zones.available.names)]])
     },
-    var.tags,
+    local.tags,
   )
   lifecycle {
     ignore_changes = [tags]
   }
 }
 
-resource "aws_subnet" "private" {
+resource "aws_subnet" "private_subnet" {
   count = var.subnet_count
 
-  vpc_id            = aws_vpc.site.id
+  vpc_id            = aws_vpc.vpc.id
   cidr_block        = cidrsubnet(var.vpc_cidr, var.subnet_count * 2, count.index + var.subnet_count)
   availability_zone = data.aws_availability_zones.available.names[count.index % length(data.aws_availability_zones.available.names)]
   tags = merge(
     {
       "Name" = join("-", [var.name_prefix, "subnet", "private${count.index + 1}", data.aws_availability_zones.available.names[count.index % length(data.aws_availability_zones.available.names)]])
     },
-    var.tags,
+    local.tags,
   )
   lifecycle {
     ignore_changes = [tags]
   }
 }
 
-
 #
 # Internet gateway
 #
-resource "aws_internet_gateway" "site" {
-  vpc_id = aws_vpc.site.id
+resource "aws_internet_gateway" "internet_gateway" {
+  vpc_id = aws_vpc.vpc.id
   tags = merge(
     {
       "Name" = "${var.name_prefix}-igw"
     },
-    var.tags,
+    local.tags,
   )
   lifecycle {
     ignore_changes = [tags]
@@ -72,7 +75,7 @@ resource "aws_internet_gateway" "site" {
 #
 # Elastic IPs for NAT gateways
 #
-resource "aws_eip" "nat" {
+resource "aws_eip" "eip" {
   count = var.subnet_count
 
   domain = "vpc"
@@ -80,28 +83,27 @@ resource "aws_eip" "nat" {
     {
       "Name" = join("-", [var.name_prefix, "eip", data.aws_availability_zones.available.names[count.index % length(data.aws_availability_zones.available.names)]])
     },
-    var.tags,
+    local.tags,
   )
   lifecycle {
     ignore_changes = [tags]
   }
 }
 
-
 #
 # NAT gateways
 #
-resource "aws_nat_gateway" "public" {
+resource "aws_nat_gateway" "public_nat_gateway" {
   count = var.subnet_count
 
-  allocation_id = aws_eip.nat[count.index].id
-  subnet_id     = aws_subnet.public[count.index].id
+  allocation_id = aws_eip.eip[count.index].id
+  subnet_id     = aws_subnet.public_subnet[count.index].id
 
   tags = merge(
     {
       "Name" = join("-", [var.name_prefix, "nat", "public${count.index}", data.aws_availability_zones.available.names[count.index % length(data.aws_availability_zones.available.names)]])
     },
-    var.tags,
+    local.tags,
   )
   lifecycle {
     ignore_changes = [tags]
@@ -111,28 +113,28 @@ resource "aws_nat_gateway" "public" {
 #
 # Route tables
 #
-resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.site.id
+resource "aws_route_table" "public_route_table" {
+  vpc_id = aws_vpc.vpc.id
   tags = merge(
     {
       "Name" = "${var.name_prefix}-public"
     },
-    var.tags,
+    local.tags,
   )
   lifecycle {
     ignore_changes = [tags]
   }
 }
 
-resource "aws_route_table" "private" {
+resource "aws_route_table" "private_route_table" {
   count = var.subnet_count
 
-  vpc_id = aws_vpc.site.id
+  vpc_id = aws_vpc.vpc.id
   tags = merge(
     {
       "Name" = join("-", [var.name_prefix, "rtb", "private${count.index}", data.aws_availability_zones.available.names[count.index % length(data.aws_availability_zones.available.names)]])
     },
-    var.tags,
+    local.tags,
   )
   lifecycle {
     ignore_changes = [tags]
@@ -144,54 +146,69 @@ resource "aws_route_table" "private" {
 #
 # Send all IPv4 traffic to the internet gateway
 resource "aws_route" "ipv4_egress_route" {
-  route_table_id         = aws_route_table.public.id
+  route_table_id         = aws_route_table.public_route_table.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.site.id
-  depends_on             = [aws_route_table.public]
+  gateway_id             = aws_internet_gateway.internet_gateway.id
+  depends_on             = [aws_route_table.public_route_table]
 }
 
 # Send all IPv6 traffic to the internet gateway
 resource "aws_route" "ipv6_egress_route" {
-  route_table_id              = aws_route_table.public.id
+  route_table_id              = aws_route_table.public_route_table.id
   destination_ipv6_cidr_block = "::/0"
-  gateway_id                  = aws_internet_gateway.site.id
-  depends_on                  = [aws_route_table.public]
+  gateway_id                  = aws_internet_gateway.internet_gateway.id
+  depends_on                  = [aws_route_table.public_route_table]
 }
 
 # Send private traffic to NAT
 resource "aws_route" "private_nat" {
   count = var.subnet_count
 
-  route_table_id         = aws_route_table.private[count.index].id
+  route_table_id         = aws_route_table.private_route_table[count.index].id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.public[count.index].id
-  depends_on             = [aws_route_table.private, aws_nat_gateway.public]
+  nat_gateway_id         = aws_nat_gateway.public_nat_gateway[count.index].id
+  depends_on             = [aws_route_table.private_route_table, aws_nat_gateway.public_nat_gateway]
 }
 
 
 # Private route for vpc endpoint
-resource "aws_vpc_endpoint_route_table_association" "private" {
+resource "aws_vpc_endpoint_route_table_association" "private_vpc_endpoint_route_table_association" {
   count = var.subnet_count
 
-  route_table_id  = aws_route_table.private[count.index].id
+  route_table_id  = aws_route_table.private_route_table[count.index].id
   vpc_endpoint_id = aws_vpc_endpoint.s3.id
 }
 
 #
 # Route table associations
 #
-resource "aws_route_table_association" "public" {
+resource "aws_route_table_association" "public_route_table_association" {
   count = var.subnet_count
 
-  subnet_id      = aws_subnet.public[count.index].id
-  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_subnet[count.index].id
+  route_table_id = aws_route_table.public_route_table.id
 }
 
-resource "aws_route_table_association" "private" {
+resource "aws_route_table_association" "private_route_table_association" {
   count = var.subnet_count
 
-  subnet_id      = aws_subnet.private[count.index].id
-  route_table_id = aws_route_table.private[count.index].id
+  subnet_id      = aws_subnet.private_subnet[count.index].id
+  route_table_id = aws_route_table.private_route_table[count.index].id
+}
+
+# This resource is used in order to add dependencies on all resources 
+# Any resource uses this VPC ID, must wait to all resources creation completion
+resource "time_sleep" "vpc_resources_wait" {
+  create_duration = "10s"
+  triggers = {
+    vpc_id                                           = aws_vpc.vpc.id
+    ipv4_egress_route_id                             = aws_route.ipv4_egress_route.id
+    ipv6_egress_route_id                             = aws_route.ipv6_egress_route.id
+    private_nat_ids                                  = jsonencode([for value in aws_route.private_nat : value.id])
+    private_vpc_endpoint_route_table_association_ids = jsonencode([for value in aws_vpc_endpoint_route_table_association.private_vpc_endpoint_route_table_association : value.id])
+    public_route_table_association_ids               = jsonencode([for value in aws_route_table_association.public_route_table_association : value.id])
+    private_route_table_association_ids              = jsonencode([for value in aws_route_table_association.private_route_table_association : value.id])
+  }
 }
 
 data "aws_region" "current" {}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,15 +1,19 @@
 output "private_subnets" {
-  value = aws_subnet.private[*].id
+  value       = aws_subnet.private_subnet[*].id
+  description = "List of private subnets created this this AWS VPC"
 }
 
 output "public_subnets" {
-  value = aws_subnet.public[*].id
+  value       = aws_subnet.public_subnet[*].id
+  description = "List of public subnets created this this AWS VPC"
 }
 
 output "availability_zones" {
-  value = slice(data.aws_availability_zones.available.names, 0, var.subnet_count)
+  value       = slice(data.aws_availability_zones.available.names, 0, var.subnet_count)
+  description = "List of the Availability Zone names used for the VPC creation"
 }
 
 output "vpc_id" {
-  value = aws_vpc.site.id
+  value       = time_sleep.vpc_resources_wait.triggers["vpc_id"]
+  description = "The unique ID of the VPC"
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,19 +1,21 @@
 variable "vpc_cidr" {
-  type    = string
-  default = "10.0.0.0/16"
+  type        = string
+  default     = "10.0.0.0/16"
+  description = "Cidr block of the desired VPC."
 }
 
 variable "name_prefix" {
-  type = string
+  type        = string
+  description = "User-defined prefix for all generated AWS resources of this VPC"
 }
 
 variable "subnet_count" {
-  description = "The number of public/private subnet pairs to make."
   type        = number
+  description = "The number of public/private subnet pairs to make."
 }
 
 variable "tags" {
   type        = map(string)
-  default     = {}
-  description = "AWS tags to be applied to created resources."
+  default     = null
+  description = "AWS tags to be applied to generated AWS resources of this VPC."
 }

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
   }
 }


### PR DESCRIPTION
This PR also fixes [OCM-6062](https://issues.redhat.com//browse/OCM-6062) - any resource depends on the VPC ID should be blocked by all networking resources created for this VPC