### PR TITLE
OCM-5000: Arrange operator-roles sub-module variables, outputs and docs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ module "rosa_cluster_classic" {
   source = "./modules/rosa-cluster-classic"
 
   cluster_name               = var.cluster_name
-  operator_role_prefix       = local.operator_role_prefix
+  operator_role_prefix       = var.create_operator_roles ? module.operator_roles[0].operator_role_prefix : local.operator_role_prefix
   openshift_version          = var.openshift_version
   replicas                   = var.replicas
   installer_role_arn         = var.create_account_roles ? module.account_iam_resources[0].account_roles_arn["Installer"] : local.sts_roles.installer_role_arn
@@ -149,5 +149,3 @@ module "rhcs_identity_provider" {
   openid         = try(each.value.openid, null)
   mapping_method = try(each.value.mapping_method, "claim")
 }
-
-

--- a/modules/operator-roles/README.md
+++ b/modules/operator-roles/README.md
@@ -1,7 +1,69 @@
 # operator-roles
 
 ## Introduction
-TODO
+
+This Terraform sub-module is responsible for overseeing the management of IAM roles utilized by operators within the cluster for their necessary actions within the AWS account.
+
+Included in this sub-module are the following permissions:
+- ROSA Ingress Operator IAM role.
+- ROSA back-end storage IAM role.
+- ROSA Machine Config Operator role.
+- ROSA Cloud Credential Operator role.
+- ROSA Image Registry Operator role.
+
+For more info see:
+
+- [operator-policies sub-module description](../operator-policies/README.md)
+- [About IAM resources for ROSA clusters that use STS](https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-about-iam-resources)
 
 <!-- BEGIN_AUTOMATED_TF_DOCS_BLOCK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.5.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.5.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.operator_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.operator_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [time_sleep.role_resources_propagation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.custom_trust_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [rhcs_rosa_operator_roles.operator_roles](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/rosa_operator_roles) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_role_prefix"></a> [account\_role\_prefix](#input\_account\_role\_prefix) | User-defined prefix for all generated AWS resources. | `string` | n/a | yes |
+| <a name="input_oidc_endpoint_url"></a> [oidc\_endpoint\_url](#input\_oidc\_endpoint\_url) | Registered OIDC configuration issuer URL, added as the trusted relationship to the operator roles. | `string` | n/a | yes |
+| <a name="input_operator_role_prefix"></a> [operator\_role\_prefix](#input\_operator\_role\_prefix) | User-defined prefix for generated AWS operator policies. Use "account-role-prefix" in case no value provided. | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | The arn path for the account/operator roles as well as their policies. Must use the same path used for "account\_iam\_roles". | `string` | `"/"` | no |
+| <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM roles in STS clusters. | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | List of AWS resource tags to apply. | `map(string)` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_operator_role_prefix"></a> [operator\_role\_prefix](#output\_operator\_role\_prefix) | Prefix used for generated AWS operator policies. |
+| <a name="output_operator_roles_arn"></a> [operator\_roles\_arn](#output\_operator\_roles\_arn) | List of Amazon Resource Names (ARNs) for all operator roles created. |
 <!-- END_AUTOMATED_TF_DOCS_BLOCK -->

--- a/modules/operator-roles/main.tf
+++ b/modules/operator-roles/main.tf
@@ -1,20 +1,15 @@
-data "rhcs_rosa_operator_roles" "operator_roles" {
-  operator_role_prefix = var.operator_role_prefix
-  account_role_prefix  = var.account_role_prefix
-
-  lifecycle {
-    # The operator_iam_roles should contains 6 elements 
-    postcondition {
-      condition     = length(self.operator_iam_roles) == 6
-      error_message = "The list of operator roles should contains 6 elements."
-    }
-  }
+locals {
+  # The "count" value should not rely on data source outputs that are undetermined during
+  # the planning stage (at first apply).
+  # Therefore, the "operator_roles_count" local variable introduced with a hardcoded value.
+  # Validation within the "rhcs_rosa_operator_roles.operator_roles" data source ensures that this
+  # value matches the actual length returned from the data source.
+  operator_roles_count = 6
+  operator_role_prefix = var.operator_role_prefix != null ? var.operator_role_prefix : var.account_role_prefix
 }
 
-data "aws_caller_identity" "current" {}
-
 resource "aws_iam_role" "operator_role" {
-  count = 6
+  count = local.operator_roles_count
 
   name                 = data.rhcs_rosa_operator_roles.operator_roles.operator_iam_roles[count.index].role_name
   path                 = var.path
@@ -23,23 +18,21 @@ resource "aws_iam_role" "operator_role" {
   assume_role_policy = data.aws_iam_policy_document.custom_trust_policy[count.index].json
 
   tags = merge(var.tags, {
-    red-hat-managed = true
-    // TODO nargaman always empty?
-    rosa_cluster_id    = var.cluster_id
+    red-hat-managed    = true
     operator_namespace = data.rhcs_rosa_operator_roles.operator_roles.operator_iam_roles[count.index].operator_namespace
     operator_name      = data.rhcs_rosa_operator_roles.operator_roles.operator_iam_roles[count.index].operator_name
   })
 }
 
 resource "aws_iam_role_policy_attachment" "operator_role_policy_attachment" {
-  count = 6
+  count = local.operator_roles_count
 
   role       = aws_iam_role.operator_role[count.index].name
   policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${data.rhcs_rosa_operator_roles.operator_roles.operator_iam_roles[count.index].policy_name}"
 }
 
 data "aws_iam_policy_document" "custom_trust_policy" {
-  count = 6
+  count = local.operator_roles_count
 
   statement {
     effect  = "Allow"
@@ -56,12 +49,27 @@ data "aws_iam_policy_document" "custom_trust_policy" {
   }
 }
 
+data "rhcs_rosa_operator_roles" "operator_roles" {
+  operator_role_prefix = local.operator_role_prefix
+  account_role_prefix  = var.account_role_prefix
+
+  lifecycle {
+    # The operator_iam_roles should contains 6 elements 
+    postcondition {
+      condition     = length(self.operator_iam_roles) == local.operator_roles_count
+      error_message = "The operator roles list returned has a length of ${length(self.operator_iam_roles)}, which differs from the expected value of ${local.operator_roles_count}. To solve this, you need to update \"local.operator_roles_count\" value to ${length(self.operator_iam_roles)} and apply again."
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
 # Wait 20 seconds after the operator role is created in order to avoid error in cluster create
 resource "time_sleep" "role_resources_propagation" {
   create_duration = "20s"
 
   triggers = {
-    operator_role_prefix = var.operator_role_prefix
-    operator_role_arns   = "[ ${join(", ", aws_iam_role.operator_role[*].arn)} ]"
+    operator_role_prefix = local.operator_role_prefix
+    operator_role_arns   = jsonencode([for value in aws_iam_role.operator_role : value.arn])
   }
 }

--- a/modules/operator-roles/outputs.tf
+++ b/modules/operator-roles/outputs.tf
@@ -1,7 +1,9 @@
 output "operator_role_prefix" {
-  value = time_sleep.role_resources_propagation.triggers["operator_role_prefix"]
+  value       = time_sleep.role_resources_propagation.triggers["operator_role_prefix"]
+  description = "Prefix used for generated AWS operator policies."
 }
 
 output "operator_roles_arn" {
-  value = { for idx, val in aws_iam_role.operator_role : data.rhcs_rosa_operator_roles.operator_roles.operator_iam_roles[idx].operator_namespace => val.arn }
+  value       = { for idx, val in aws_iam_role.operator_role : data.rhcs_rosa_operator_roles.operator_roles.operator_iam_roles[idx].operator_namespace => val.arn }
+  description = "List of Amazon Resource Names (ARNs) for all operator roles created."
 }

--- a/modules/operator-roles/variables.tf
+++ b/modules/operator-roles/variables.tf
@@ -1,36 +1,33 @@
 variable "operator_role_prefix" {
-  type = string
+  type        = string
+  default     = null
+  description = "User-defined prefix for generated AWS operator policies. Use \"account-role-prefix\" in case no value provided."
 }
 
 variable "account_role_prefix" {
-  type = string
+  type        = string
+  description = "User-defined prefix for all generated AWS resources."
 }
 
 variable "path" {
-  description = "(Optional) The arn path for the account/operator roles as well as their policies."
   type        = string
   default     = "/"
+  description = "The arn path for the account/operator roles as well as their policies. Must use the same path used for \"account_iam_roles\"."
 }
 
 variable "permissions_boundary" {
+  type        = string
+  default     = ""
   description = "The ARN of the policy that is used to set the permissions boundary for the IAM roles in STS clusters."
-  type        = string
-  default     = ""
-}
-
-variable "cluster_id" {
-  description = "cluster ID"
-  type        = string
-  default     = ""
 }
 
 variable "tags" {
-  description = "List of AWS resource tags to apply."
   type        = map(string)
   default     = null
+  description = "List of AWS resource tags to apply."
 }
 
 variable "oidc_endpoint_url" {
-  description = "oidc provider url"
   type        = string
+  description = "Registered OIDC configuration issuer URL, added as the trusted relationship to the operator roles."
 }


### PR DESCRIPTION
This PR also fix dependency between ROSA cluster to operator_roles in the root module