### PR TITLE
OCM-6129: Refactor IDP sub-module

### DIFF
--- a/examples/rosa-classic-public-with-idp-machine-pools/main.tf
+++ b/examples/rosa-classic-public-with-idp-machine-pools/main.tf
@@ -1,4 +1,3 @@
-
 module "rosa" {
   source = "../../"
 
@@ -19,14 +18,38 @@ module "rosa" {
       "replicas" : 3
     }
   }
-  idp = {
-    "1" : {
-      "name" : "idp1",
-      "gitlab" = {
-        "client_id"     = "2189835314857134"
-        "client_secret" = "DG66575SKFGMdDFDSDSGTFSB47634735VDSFFDV"
-        "url"           = "https://gitlab.com"
-      }
-    }
-  }
+}
+
+module "gitlab_idp" {
+  source = "../../modules/idp"
+
+  cluster_id = module.rosa.cluster_id
+  name       = "gitlab-idp"
+  idp_type   = "gitlab"
+  # Utilize randomly generated values for "client_id" and "client_secret" to ensure the example configuration:
+  # 1. Enables the file to run seamlessly without modifications.
+  # 2. Avoid security alerts on "Potential data leak"
+  # Please note that these are not real account credentials, and access to the cluster itself is not feasible.
+  # To enable GitLab IDP functionality, substitute these random values with valid credentials.
+  gitlab_idp_client_id     = random_password.client_id.result     # replace with valid <client-id>
+  gitlab_idp_client_secret = random_password.client_secret.result # replace with valid <client-secret>
+  gitlab_idp_url           = "https://gitlab.com"
+}
+
+resource "random_password" "client_id" {
+  length = 16
+
+  numeric = true
+  upper   = false
+  lower   = false
+  special = false
+}
+
+resource "random_password" "client_secret" {
+  length = 39
+
+  numeric = true
+  upper   = true
+  lower   = false
+  special = false
 }

--- a/examples/rosa-classic-public-with-idp-machine-pools/versions.tf
+++ b/examples/rosa-classic-public-with-idp-machine-pools/versions.tf
@@ -10,5 +10,9 @@ terraform {
       version = ">= 1.5.0"
       source  = "terraform-redhat/rhcs"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -128,22 +128,3 @@ module "rhcs_machine_pool" {
   taints              = try(each.value.taints, null)
   labels              = try(each.value.labels, null)
 }
-
-############################
-# idp
-############################
-
-module "rhcs_identity_provider" {
-  source   = "./modules/idp"
-  for_each = var.idp
-
-  cluster_id     = module.rosa_cluster_classic.cluster_id
-  name           = each.value.name
-  github         = try(each.value.github, null)
-  gitlab         = try(each.value.gitlab, null)
-  google         = try(each.value.google, null)
-  htpasswd       = try(each.value.htpasswd, null)
-  ldap           = try(each.value.ldap, null)
-  openid         = try(each.value.openid, null)
-  mapping_method = try(each.value.mapping_method, "claim")
-}

--- a/modules/idp/README.md
+++ b/modules/idp/README.md
@@ -1,10 +1,87 @@
 # idp
 
 ## Introduction
-TODO
+
+This Terraform sub-module facilitates the configuration of Identity Providers (IDPs) for Red Hat OpenShift Service on AWS (ROSA) clusters. It offers support for various IDP types, including GitHub, GitLab, Google, HTPasswd, LDAP, and OpenID. With this module, users can seamlessly integrate external authentication mechanisms into their ROSA clusters, enhancing security and user management capabilities. By enabling the configuration of different IDP types, users can tailor authentication methods to their specific requirements, ensuring flexibility and compatibility within the ROSA cluster environment deployed on AWS.
+
+For more info see [Configuring identity providers for STS](https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.html)
 
 ## Prerequisites
-TODO
+
+Ensure that you have an existing Red Hat OpenShift Service on AWS (ROSA) cluster deployed on AWS. (see [rosa-cluster-classic sub-module](../rosa-cluster-classic/README.md))
 
 <!-- BEGIN_AUTOMATED_TF_DOCS_BLOCK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | 1.5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [rhcs_identity_provider.github_identity_provider](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/identity_provider) | resource |
+| [rhcs_identity_provider.gitlab_identity_provider](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/identity_provider) | resource |
+| [rhcs_identity_provider.google_identity_provider](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/identity_provider) | resource |
+| [rhcs_identity_provider.htpasswd_identity_provider](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/identity_provider) | resource |
+| [rhcs_identity_provider.ldap_identity_provider](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/identity_provider) | resource |
+| [rhcs_identity_provider.openid_identity_provider](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/identity_provider) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Identifier of the cluster. | `string` | n/a | yes |
+| <a name="input_github_idp_ca"></a> [github\_idp\_ca](#input\_github\_idp\_ca) | Path to PEM-encoded certificate file to use when making requests to the server (optional). Valid only to Github Identity Provider (idp\_type=github) | `string` | `null` | no |
+| <a name="input_github_idp_client_id"></a> [github\_idp\_client\_id](#input\_github\_idp\_client\_id) | Client secret issued by Github (required). Valid only to Github Identity Provider (idp\_type=github) | `string` | `null` | no |
+| <a name="input_github_idp_client_secret"></a> [github\_idp\_client\_secret](#input\_github\_idp\_client\_secret) | Client secret issued by Github (required). Valid only to Github Identity Provider (idp\_type=github) | `string` | `null` | no |
+| <a name="input_github_idp_hostname"></a> [github\_idp\_hostname](#input\_github\_idp\_hostname) | Optional domain to use with a hosted instance of GitHub Enterprise (optional). Valid only to Github Identity Provider (idp\_type=github) | `string` | `null` | no |
+| <a name="input_github_idp_organizations"></a> [github\_idp\_organizations](#input\_github\_idp\_organizations) | Only users that are members of at least one of the listed organizations will be allowed to log in (optional). Valid only to Github Identity Provider (idp\_type=github) | `list(string)` | `null` | no |
+| <a name="input_github_idp_teams"></a> [github\_idp\_teams](#input\_github\_idp\_teams) | Only users that are members of at least one of the listed teams will be allowed to log in. The format is `<org>`/`<team>` (optional). Valid only to Github Identity Provider (idp\_type=github) | `list(string)` | `null` | no |
+| <a name="input_gitlab_idp_ca"></a> [gitlab\_idp\_ca](#input\_gitlab\_idp\_ca) | Trusted certificate authority bundle (optional). Valid only to Gitlab Identity Provider (idp\_type=gitlab) | `string` | `null` | no |
+| <a name="input_gitlab_idp_client_id"></a> [gitlab\_idp\_client\_id](#input\_gitlab\_idp\_client\_id) | Client identifier of a registered Gitlab OAuth application (required). Valid only to Gitlab Identity Provider (idp\_type=gitlab) | `string` | `null` | no |
+| <a name="input_gitlab_idp_client_secret"></a> [gitlab\_idp\_client\_secret](#input\_gitlab\_idp\_client\_secret) | Client secret issued by Gitlab (required). Valid only to Gitlab Identity Provider (idp\_type=gitlab) | `string` | `null` | no |
+| <a name="input_gitlab_idp_url"></a> [gitlab\_idp\_url](#input\_gitlab\_idp\_url) | URL of the Gitlab instance (required). Valid only to Gitlab Identity Provider (idp\_type=gitlab) | `string` | `null` | no |
+| <a name="input_google_idp_client_id"></a> [google\_idp\_client\_id](#input\_google\_idp\_client\_id) | Client identifier of a registered Google OAuth application (required). Valid only to Google Identity Provider (idp\_type=google) | `string` | `null` | no |
+| <a name="input_google_idp_client_secret"></a> [google\_idp\_client\_secret](#input\_google\_idp\_client\_secret) | Client secret issued by Google (required). Valid only to Google Identity Provider (idp\_type=google) | `string` | `null` | no |
+| <a name="input_google_idp_hosted_domain"></a> [google\_idp\_hosted\_domain](#input\_google\_idp\_hosted\_domain) | Restrict users to a Google Apps domain (optional). Valid only to Google Identity Provider (idp\_type=google) | `string` | `null` | no |
+| <a name="input_htpasswd_idp_users"></a> [htpasswd\_idp\_users](#input\_htpasswd\_idp\_users) | A list of htpasswd user credentials (required). Valid only to Htpasswd Identity Provider (idp\_type=htpasswd) | <pre>list(object({<br>    username = string<br>    password = string<br>  }))</pre> | `null` | no |
+| <a name="input_idp_type"></a> [idp\_type](#input\_idp\_type) | n/a | `string` | n/a | yes |
+| <a name="input_ldap_idp_bind_dn"></a> [ldap\_idp\_bind\_dn](#input\_ldap\_idp\_bind\_dn) | DN to bind with during the search phase (optional). Valid only to Ldap Identity Provider (idp\_type=ldap) | `string` | `null` | no |
+| <a name="input_ldap_idp_bind_password"></a> [ldap\_idp\_bind\_password](#input\_ldap\_idp\_bind\_password) | Password to bind with during the search phase (optional). Valid only to Ldap Identity Provider (idp\_type=ldap) | `string` | `null` | no |
+| <a name="input_ldap_idp_ca"></a> [ldap\_idp\_ca](#input\_ldap\_idp\_ca) | Trusted certificate authority bundle (optional). Valid only to Ldap Identity Provider (idp\_type=ldap) | `string` | `null` | no |
+| <a name="input_ldap_idp_emails"></a> [ldap\_idp\_emails](#input\_ldap\_idp\_emails) | The list of attributes whose values should be used as the email address (optional). Valid only to Ldap Identity Provider (idp\_type=ldap) | `list(string)` | `null` | no |
+| <a name="input_ldap_idp_ids"></a> [ldap\_idp\_ids](#input\_ldap\_idp\_ids) | The list of attributes whose values should be used as the user ID. Default ['dn'] (optional). Valid only to Ldap Identity Provider (idp\_type=ldap) | `list(string)` | `null` | no |
+| <a name="input_ldap_idp_insecure"></a> [ldap\_idp\_insecure](#input\_ldap\_idp\_insecure) | Do not make TLS connections to the server (optional). Valid only to Ldap Identity Provider (idp\_type=ldap) | `bool` | `null` | no |
+| <a name="input_ldap_idp_names"></a> [ldap\_idp\_names](#input\_ldap\_idp\_names) | The list of attributes whose values should be used as the display name. Default ['cn'] (optional). Valid only to Ldap Identity Provider (idp\_type=ldap) | `list(string)` | `null` | no |
+| <a name="input_ldap_idp_preferred_usernames"></a> [ldap\_idp\_preferred\_usernames](#input\_ldap\_idp\_preferred\_usernames) | The list of attributes whose values should be used as the preferred username. Default ['uid'] (optional). Valid only to Ldap Identity Provider (idp\_type=ldap) | `list(string)` | `null` | no |
+| <a name="input_ldap_idp_url"></a> [ldap\_idp\_url](#input\_ldap\_idp\_url) | An RFC 2255 URL which specifies the LDAP search parameters to use (required). Valid only to Ldap Identity Provider (idp\_type=ldap) | `string` | `null` | no |
+| <a name="input_mapping_method"></a> [mapping\_method](#input\_mapping\_method) | Specifies how new identities are mapped to users when they log in. Options are add, claim, generate and lookup. (default is claim) | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the identity provider. | `string` | n/a | yes |
+| <a name="input_openid_idp_ca"></a> [openid\_idp\_ca](#input\_openid\_idp\_ca) | Trusted certificate authority bundle (optional). Valid only to OpenID Identity Provider (idp\_type=openid) | `string` | `null` | no |
+| <a name="input_openid_idp_claims_email"></a> [openid\_idp\_claims\_email](#input\_openid\_idp\_claims\_email) | List of claims to use as the email address (optional). Valid only to OpenID Identity Provider (idp\_type=openid) | `list(string)` | `null` | no |
+| <a name="input_openid_idp_claims_groups"></a> [openid\_idp\_claims\_groups](#input\_openid\_idp\_claims\_groups) | List of claims to use as the groups names (optional). Valid only to OpenID Identity Provider (idp\_type=openid) | `list(string)` | `null` | no |
+| <a name="input_openid_idp_claims_name"></a> [openid\_idp\_claims\_name](#input\_openid\_idp\_claims\_name) | List of claims to use as the display name (optional). Valid only to OpenID Identity Provider (idp\_type=openid) | `list(string)` | `null` | no |
+| <a name="input_openid_idp_claims_preferred_username"></a> [openid\_idp\_claims\_preferred\_username](#input\_openid\_idp\_claims\_preferred\_username) | List of claims to use as the preferred username when provisioning a user (optional). Valid only to OpenID Identity Provider (idp\_type=openid) | `list(string)` | `null` | no |
+| <a name="input_openid_idp_client_id"></a> [openid\_idp\_client\_id](#input\_openid\_idp\_client\_id) | Client ID from the registered application (required). Valid only to OpenID Identity Provider (idp\_type=openid) | `string` | `null` | no |
+| <a name="input_openid_idp_client_secret"></a> [openid\_idp\_client\_secret](#input\_openid\_idp\_client\_secret) | Client Secret from the registered application (required). Valid only to OpenID Identity Provider (idp\_type=openid) | `string` | `null` | no |
+| <a name="input_openid_idp_extra_authorize_parameters"></a> [openid\_idp\_extra\_authorize\_parameters](#input\_openid\_idp\_extra\_authorize\_parameters) | Extra authorization parameters for the OpenID Identity Provider (optional). Valid only to OpenID Identity Provider (idp\_type=openid) | `map(string)` | `null` | no |
+| <a name="input_openid_idp_extra_scopes"></a> [openid\_idp\_extra\_scopes](#input\_openid\_idp\_extra\_scopes) | List of scopes to request, in addition to the 'openid' scope, during the authorization token request (optional). Valid only to OpenID Identity Provider (idp\_type=openid) | `list(string)` | `null` | no |
+| <a name="input_openid_idp_issuer"></a> [openid\_idp\_issuer](#input\_openid\_idp\_issuer) | The URL that the OpenID Provider asserts as the Issuer Identifier. It must use the https scheme with no URL query parameters or fragment (required). Valid only to OpenID Identity Provider (idp\_type=openid) | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
 <!-- END_AUTOMATED_TF_DOCS_BLOCK -->

--- a/modules/idp/main.tf
+++ b/modules/idp/main.tf
@@ -1,13 +1,158 @@
-resource "rhcs_identity_provider" "identity_provider" {
+resource "rhcs_identity_provider" "github_identity_provider" {
+  count = lower(var.idp_type) == "github" ? 1 : 0
+
   cluster        = var.cluster_id
   name           = var.name
-  github         = var.github
-  gitlab         = var.gitlab
-  google         = var.google
-  htpasswd       = var.htpasswd
-  ldap           = var.ldap
-  openid         = var.openid
   mapping_method = var.mapping_method
+  github = {
+    client_id     = var.github_idp_client_id
+    client_secret = var.github_idp_client_secret
+    ca            = var.github_idp_ca
+    hostname      = var.github_idp_hostname
+    organizations = var.github_idp_organizations
+    teams         = var.github_idp_teams
+  }
+
+  lifecycle {
+    precondition {
+      condition     = (lower(var.idp_type) == "github" && var.github_idp_client_id == null) == false
+      error_message = "\"github_idp_client_id\" mustn't be empty when creating Github Identity Provider."
+    }
+    precondition {
+      condition     = (lower(var.idp_type) == "github" && var.github_idp_client_secret == null) == false
+      error_message = "\"github_idp_client_secret\" mustn't be empty when creating Github Identity Provider."
+    }
+  }
 }
 
+resource "rhcs_identity_provider" "gitlab_identity_provider" {
+  count = lower(var.idp_type) == "gitlab" ? 1 : 0
 
+  cluster        = var.cluster_id
+  name           = var.name
+  mapping_method = var.mapping_method
+  gitlab = {
+    client_id     = var.gitlab_idp_client_id
+    client_secret = var.gitlab_idp_client_secret
+    url           = var.gitlab_idp_url
+    ca            = var.gitlab_idp_ca
+  }
+
+  lifecycle {
+    precondition {
+      condition     = (lower(var.idp_type) == "gitlab" && var.gitlab_idp_client_id == null) == false
+      error_message = "\"gitlab_idp_client_id\" mustn't be empty when creating Gitlab Identity Provider."
+    }
+    precondition {
+      condition     = (lower(var.idp_type) == "gitlab" && var.gitlab_idp_client_secret == null) == false
+      error_message = "\"gitlab_idp_client_secret\" mustn't be empty when creating Gitlab Identity Provider."
+    }
+    precondition {
+      condition     = (lower(var.idp_type) == "gitlab" && var.gitlab_idp_url == null) == false
+      error_message = "\"gitlab_idp_url\" mustn't be empty when creating Gitlab Identity Provider."
+    }
+  }
+}
+
+resource "rhcs_identity_provider" "google_identity_provider" {
+  count = lower(var.idp_type) == "google" ? 1 : 0
+
+  cluster        = var.cluster_id
+  name           = var.name
+  mapping_method = var.mapping_method
+  google = {
+    client_id     = var.google_idp_client_id
+    client_secret = var.google_idp_client_secret
+    hosted_domain = var.google_idp_hosted_domain
+  }
+
+  lifecycle {
+    precondition {
+      condition     = (lower(var.idp_type) == "google" && var.google_idp_client_id == null) == false
+      error_message = "\"google_idp_client_id\" mustn't be empty when creating Google Identity Provider."
+    }
+    precondition {
+      condition     = (lower(var.idp_type) == "google" && var.google_idp_client_secret == null) == false
+      error_message = "\"google_idp_client_secret\" mustn't be empty when creating Google Identity Provider."
+    }
+  }
+}
+
+resource "rhcs_identity_provider" "htpasswd_identity_provider" {
+  count = lower(var.idp_type) == "htpasswd" ? 1 : 0
+
+  cluster        = var.cluster_id
+  name           = var.name
+  mapping_method = var.mapping_method
+  htpasswd = {
+    users = var.htpasswd_idp_users
+  }
+
+  lifecycle {
+    precondition {
+      condition     = (lower(var.idp_type) == "htpasswd" && var.htpasswd_idp_users == null) == false
+      error_message = "\"htpasswd_idp_users\" mustn't be empty when creating Htpasswd Identity Provider."
+    }
+  }
+}
+
+resource "rhcs_identity_provider" "ldap_identity_provider" {
+  count = lower(var.idp_type) == "ldap" ? 1 : 0
+
+  cluster        = var.cluster_id
+  name           = var.name
+  mapping_method = var.mapping_method
+  ldap = {
+    bind_dn       = var.ldap_idp_bind_dn
+    bind_password = var.ldap_idp_bind_password
+    ca            = var.ldap_idp_ca
+    insecure      = var.ldap_idp_insecure
+    url           = var.ldap_idp_url
+    attributes = {
+      email              = var.ldap_idp_emails
+      id                 = var.ldap_idp_ids
+      name               = var.ldap_idp_names
+      preferred_username = var.ldap_idp_preferred_usernames
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = (lower(var.idp_type) == "ldap" && var.ldap_idp_url == null) == false
+      error_message = "\"ldap_idp_url\" mustn't be empty when creating LDAP Identity Provider."
+    }
+  }
+}
+
+resource "rhcs_identity_provider" "openid_identity_provider" {
+  count = lower(var.idp_type) == "openid" ? 1 : 0
+
+  cluster        = var.cluster_id
+  name           = var.name
+  mapping_method = var.mapping_method
+  openid = {
+    ca = var.openid_idp_ca
+    claims = {
+      email              = var.openid_idp_claims_email
+      groups             = var.openid_idp_claims_groups
+      name               = var.openid_idp_claims_name
+      preferred_username = var.openid_idp_claims_preferred_username
+    }
+    client_id                  = var.openid_idp_client_id
+    client_secret              = var.openid_idp_client_secret
+    extra_scopes               = var.openid_idp_extra_scopes
+    extra_authorize_parameters = var.openid_idp_extra_authorize_parameters
+    issuer                     = var.openid_idp_issuer
+  }
+
+  lifecycle {
+    precondition {
+      condition     = (lower(var.idp_type) == "openid" && var.openid_idp_client_id == null) == false
+      error_message = "\"openid_idp_client_id\" mustn't be empty when creating OpenID Identity Provider."
+    }
+    precondition {
+      condition     = (lower(var.idp_type) == "openid" && var.openid_idp_client_secret == null) == false
+      error_message = "\"openid_idp_client_secret\" mustn't be empty when creating OpenID Identity Provider."
+    }
+  }
+}

--- a/modules/idp/variables.tf
+++ b/modules/idp/variables.tf
@@ -1,52 +1,249 @@
-// Required
 variable "cluster_id" {
   description = "Identifier of the cluster."
   type        = string
 }
 
-// Required
 variable "name" {
   description = "Name of the identity provider."
   type        = string
 }
 
-variable "github" {
-  description = "Details of the Github identity provider."
-  type        = map(any)
-  default     = {}
-}
-
-variable "gitlab" {
-  description = "Details of the Gitlab identity provider. "
-  type        = map(any)
-  default     = {}
-}
-
-variable "google" {
-  description = "Details of the Google identity provider."
-  type        = map(any)
-  default     = {}
-}
-
-variable "htpasswd" {
-  description = "Details of the 'htpasswd' identity provider. "
-  type        = map(any)
-  default     = {}
-}
-
-variable "ldap" {
-  description = "Details of the LDAP identity provider"
-  type        = map(any)
-  default     = {}
-}
-
-variable "openid" {
-  description = "Details of the OpenID identity provider."
-  type        = map(any)
-  default     = {}
+variable "idp_type" {
+  type        = string
+  description = ""
+  validation {
+    condition     = contains(["github", "gitlab", "google", "htpasswd", "ldap", "openid"], lower(var.idp_type))
+    error_message = " idp_type must be one of the following: [\"github\", \"gitlab\", \"google\", \"htpasswd\", \"ldap\", \"openid\"]"
+  }
 }
 
 variable "mapping_method" {
-  description = "Specifies how new identities are mapped to users when they log in. Options are add, claim, generate and lookup. (default is claim)"
   type        = string
+  default     = null
+  description = "Specifies how new identities are mapped to users when they log in. Options are add, claim, generate and lookup. (default is claim)"
+}
+
+#########################
+# Github IDP
+#########################
+
+variable "github_idp_client_id" {
+  type        = string
+  default     = null
+  description = "Client secret issued by Github (required). Valid only to Github Identity Provider (idp_type=github)"
+}
+
+variable "github_idp_client_secret" {
+  type        = string
+  default     = null
+  description = "Client secret issued by Github (required). Valid only to Github Identity Provider (idp_type=github)"
+}
+
+variable "github_idp_ca" {
+  type        = string
+  default     = null
+  description = "Path to PEM-encoded certificate file to use when making requests to the server (optional). Valid only to Github Identity Provider (idp_type=github)"
+}
+
+variable "github_idp_hostname" {
+  type        = string
+  default     = null
+  description = "Optional domain to use with a hosted instance of GitHub Enterprise (optional). Valid only to Github Identity Provider (idp_type=github)"
+}
+
+variable "github_idp_organizations" {
+  type        = list(string)
+  default     = null
+  description = "Only users that are members of at least one of the listed organizations will be allowed to log in (optional). Valid only to Github Identity Provider (idp_type=github)"
+}
+
+variable "github_idp_teams" {
+  type        = list(string)
+  default     = null
+  description = "Only users that are members of at least one of the listed teams will be allowed to log in. The format is `<org>`/`<team>` (optional). Valid only to Github Identity Provider (idp_type=github)"
+}
+
+#########################
+# Gitlab IDP
+#########################
+
+variable "gitlab_idp_client_id" {
+  type        = string
+  default     = null
+  description = "Client identifier of a registered Gitlab OAuth application (required). Valid only to Gitlab Identity Provider (idp_type=gitlab)"
+}
+
+variable "gitlab_idp_client_secret" {
+  type        = string
+  default     = null
+  description = "Client secret issued by Gitlab (required). Valid only to Gitlab Identity Provider (idp_type=gitlab)"
+}
+
+variable "gitlab_idp_url" {
+  type        = string
+  default     = null
+  description = "URL of the Gitlab instance (required). Valid only to Gitlab Identity Provider (idp_type=gitlab)"
+}
+
+variable "gitlab_idp_ca" {
+  type        = string
+  default     = null
+  description = "Trusted certificate authority bundle (optional). Valid only to Gitlab Identity Provider (idp_type=gitlab)"
+}
+
+#########################
+# Google IDP
+#########################
+
+variable "google_idp_client_id" {
+  type        = string
+  default     = null
+  description = "Client identifier of a registered Google OAuth application (required). Valid only to Google Identity Provider (idp_type=google)"
+}
+
+variable "google_idp_client_secret" {
+  type        = string
+  default     = null
+  description = "Client secret issued by Google (required). Valid only to Google Identity Provider (idp_type=google)"
+}
+
+variable "google_idp_hosted_domain" {
+  type        = string
+  default     = null
+  description = "Restrict users to a Google Apps domain (optional). Valid only to Google Identity Provider (idp_type=google)"
+}
+
+#########################
+# Htpasswd IDP
+#########################
+
+variable "htpasswd_idp_users" {
+  type = list(object({
+    username = string
+    password = string
+  }))
+  default     = null
+  description = "A list of htpasswd user credentials (required). Valid only to Htpasswd Identity Provider (idp_type=htpasswd)"
+}
+
+#########################
+# LDAP IDP
+#########################
+
+variable "ldap_idp_bind_dn" {
+  type        = string
+  default     = null
+  description = "DN to bind with during the search phase (optional). Valid only to Ldap Identity Provider (idp_type=ldap)"
+}
+
+variable "ldap_idp_bind_password" {
+  type        = string
+  default     = null
+  description = "Password to bind with during the search phase (optional). Valid only to Ldap Identity Provider (idp_type=ldap)"
+}
+
+variable "ldap_idp_ca" {
+  type        = string
+  default     = null
+  description = "Trusted certificate authority bundle (optional). Valid only to Ldap Identity Provider (idp_type=ldap)"
+}
+
+variable "ldap_idp_insecure" {
+  type        = bool
+  default     = null
+  description = "Do not make TLS connections to the server (optional). Valid only to Ldap Identity Provider (idp_type=ldap)"
+}
+
+variable "ldap_idp_url" {
+  type        = string
+  default     = null
+  description = "An RFC 2255 URL which specifies the LDAP search parameters to use (required). Valid only to Ldap Identity Provider (idp_type=ldap)"
+}
+
+variable "ldap_idp_emails" {
+  type        = list(string)
+  default     = null
+  description = "The list of attributes whose values should be used as the email address (optional). Valid only to Ldap Identity Provider (idp_type=ldap)"
+}
+
+variable "ldap_idp_ids" {
+  type        = list(string)
+  default     = null
+  description = "The list of attributes whose values should be used as the user ID. Default ['dn'] (optional). Valid only to Ldap Identity Provider (idp_type=ldap)"
+}
+
+variable "ldap_idp_names" {
+  type        = list(string)
+  default     = null
+  description = "The list of attributes whose values should be used as the display name. Default ['cn'] (optional). Valid only to Ldap Identity Provider (idp_type=ldap)"
+}
+
+variable "ldap_idp_preferred_usernames" {
+  type        = list(string)
+  default     = null
+  description = "The list of attributes whose values should be used as the preferred username. Default ['uid'] (optional). Valid only to Ldap Identity Provider (idp_type=ldap)"
+}
+
+#########################
+# OpenID IDP
+#########################
+
+variable "openid_idp_ca" {
+  type        = string
+  default     = null
+  description = "Trusted certificate authority bundle (optional). Valid only to OpenID Identity Provider (idp_type=openid)"
+}
+
+variable "openid_idp_claims_email" {
+  type        = list(string)
+  default     = null
+  description = "List of claims to use as the email address (optional). Valid only to OpenID Identity Provider (idp_type=openid)"
+}
+
+variable "openid_idp_claims_groups" {
+  type        = list(string)
+  default     = null
+  description = "List of claims to use as the groups names (optional). Valid only to OpenID Identity Provider (idp_type=openid)"
+}
+
+variable "openid_idp_claims_name" {
+  type        = list(string)
+  default     = null
+  description = "List of claims to use as the display name (optional). Valid only to OpenID Identity Provider (idp_type=openid)"
+}
+
+variable "openid_idp_claims_preferred_username" {
+  type        = list(string)
+  default     = null
+  description = "List of claims to use as the preferred username when provisioning a user (optional). Valid only to OpenID Identity Provider (idp_type=openid)"
+}
+
+variable "openid_idp_client_id" {
+  type        = string
+  default     = null
+  description = "Client ID from the registered application (required). Valid only to OpenID Identity Provider (idp_type=openid)"
+}
+
+variable "openid_idp_client_secret" {
+  type        = string
+  default     = null
+  description = "Client Secret from the registered application (required). Valid only to OpenID Identity Provider (idp_type=openid)"
+}
+
+variable "openid_idp_extra_scopes" {
+  type        = list(string)
+  default     = null
+  description = "List of scopes to request, in addition to the 'openid' scope, during the authorization token request (optional). Valid only to OpenID Identity Provider (idp_type=openid)"
+}
+
+variable "openid_idp_extra_authorize_parameters" {
+  type        = map(string)
+  default     = null
+  description = "Extra authorization parameters for the OpenID Identity Provider (optional). Valid only to OpenID Identity Provider (idp_type=openid)"
+}
+
+variable "openid_idp_issuer" {
+  type        = string
+  default     = null
+  description = "The URL that the OpenID Provider asserts as the Issuer Identifier. It must use the https scheme with no URL query parameters or fragment (required). Valid only to OpenID Identity Provider (idp_type=openid)"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "cluster_id" {
+  value       = module.rosa_cluster_classic.cluster_id
+  description = "Unique identifier of the cluster."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -54,11 +54,6 @@ variable "replicas" {
   default     = 3
 }
 
-variable "idp" {
-  type    = map(any)
-  default = {}
-}
-
 variable "machine_cidr" {
   type    = string
   default = "10.0.0.0/16"


### PR DESCRIPTION
* Add all IDP variables explicit in the sub-module
* Allow only one idp type
* Main module not including idp, call it from the example instead
* Arrange REDME