### PR TITLE
chore: update OWNERS approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,11 @@
 approvers:
-- bardielle
-- sagidayan
-- nirarg
-- enriquebelarte
-- gdbranco
-- ciaranRoche
-- robpblake
-- hunterkepley
-- jerichokeyne
 - olucasfreitas
+- jerichokeyne
 - amandahla
+- BraeTroutman
+- marcolan018
+- gdbranco
+- robpblake
+- davidleerh
+- willkutler
+- red-hat-konflux[bot]


### PR DESCRIPTION
## Summary
- replace the `OWNERS` approver list with the requested maintainers and Konflux bot
- remove approvers that are not part of the requested roster

## Test plan
- [x] Verified `OWNERS` matches the requested approver list exactly
- [x] Verified `git diff main...HEAD` only changes `OWNERS`