### PR TITLE
OCM-24298 | ci: align renovate, CodeRabbit, gitleaks, and Trivy with …

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,87 @@
+inheritance: true
+reviews:
+  path_filters:
+    - "!**/.terraform/**"
+    - "!**/terraform.tfstate*"
+
+  path_instructions:
+    - path: "**/*.tf"
+      instructions: |
+        **ROSA Classic only** — not ROSA HCP (see terraform-rhcs-rosa-hcp).
+        **rhcs** registry schemas are authoritative; do not invent attributes.
+        Root **versions.tf** sets minimum **rhcs** / **aws** / other providers
+        for the **entire** tree; raise root when any submodule raises a floor.
+        AWS-only work must match **Module scope** in
+        .cursor/rules/rosa-classic-terraform.mdc. Variables: snake_case;
+        **sensitive** on secrets; no long-lived keys in HCL. Finer points
+        (validation, import-safe count/for_each): see **AGENTS.md** and
+        .cursor/rules.
+
+    - path: "modules/**"
+      instructions: |
+        Submodule changes affect root, **examples/**, and downstream users.
+
+        1. **Breaking changes:** No silent renames/retypes of variables or
+           outputs; migration plan or explicit PR callout (AGENTS.md).
+
+        2. **Provider floor:** **required_providers** changes → update root
+           **versions.tf** for the whole module tree.
+
+        3. **IAM / STS / OIDC / IRSA:** Least privilege; link non-obvious
+           patterns to official **ROSA Classic** docs (control plane in the
+           customer account).
+
+        4. **Ordering:** IAM/STS eventual consistency — **depends_on** /
+           waits / preconditions where immediate effect is assumed.
+
+        5. **Tests / examples:** Update **modules/*/tests/*.tftest.hcl** and
+           keep **make verify** green for touched **examples/**.
+
+        6. **modules/rosa-cluster-classic:** **rhcs_cluster_rosa_classic** (and
+           related Classic rhcs resources) — match provider docs; document
+           minimum OpenShift version for version-gated features.
+
+        7. **modules/operator-roles**, **modules/oidc-config-and-provider**,
+           **modules/machine-pool:** Align with Classic STS/OIDC and pool
+           patterns; prefer narrow bindings over broad IAM.
+
+    - path: "examples/**/*.tf"
+      instructions: |
+        **make verify** (init + validate per example) must stay passing.
+        No embedded credentials; follow existing auth patterns.
+
+    - path: "**/*.tftest.hcl"
+      instructions: |
+        Per **CONTRIBUTING.md** / **AGENTS.md**: mocks where the repo does;
+        branch on booleans → cover both outcomes. Tests live under
+        **modules/<name>/tests/** (see **make unit-tests** / README).
+
+    - path: "scripts/**"
+      instructions: |
+        No secret leakage. Behavior must stay aligned with **CONTRIBUTING.md**
+        (fmt, terraform-docs, verify-gen, verify).
+
+    - path: ".github/workflows/**"
+      instructions: |
+        CI changes affect every PR: keep **make verify**, lint, and doc
+        generation behavior consistent with **CONTRIBUTING.md**; avoid
+        weakening checks without an explicit rationale in the PR.
+  tools:
+    checkov:
+      enabled: true
+    gitleaks:
+      enabled: true
+    golangci-lint:
+      enabled: false
+    hadolint:
+      enabled: true
+    markdownlint:
+      enabled: false
+    shellcheck:
+      enabled: true
+    tflint:
+      enabled: true
+    trivy:
+      enabled: true
+    yamllint:
+      enabled: true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# Gitleaks — https://github.com/gitleaks/gitleaks/blob/master/README.md
+# Used by CodeRabbit when gitleaks is enabled (.coderabbit.yaml) and by CI/local
+# `gitleaks detect`. Extends upstream default rules.
+#
+# **/*.tftest.hcl harnesses may use mocks/placeholders — not live credentials.
+
+title = "terraform-rhcs-rosa-classic"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Terraform CLI test configs may contain mock tokens/placeholders."
+paths = [
+  # e.g. modules/*/tests/*.tftest.hcl
+  '''\.tftest''',
+]

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# Misconfiguration IDs to skip — see https://trivy.dev/latest/docs/configuration/filtering/
+# Prefer `#trivy:ignore:<ID>` on Terraform resources; use this file when required (e.g. Dockerfile).
+
+# Root Dockerfile: tooling image installs yum/terraform/aws/rosa/terraform-docs as root; no non-root USER by design.
+DS-0002

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,16 @@ Useful skills for this codebase:
 - Use **`sensitive`** on variables and outputs where values must not appear in logs or casual `terraform show` output; avoid echoing secrets in `local` values used only for debugging.
 - Do not add logging, outputs, or comments that expose credentials or session tokens.
 
+## Trivy (IaC misconfiguration)
+
+Repo config: root **`trivy.yaml`** (severity, scanners, skips; includes **`examples/`**). CodeRabbit may run Trivy when enabled in **`.coderabbit.yaml`**. References: [Trivy config file](https://trivy.dev/latest/docs/references/configuration/config-file/), [filtering / ignores](https://trivy.dev/latest/docs/configuration/filtering/).
+
+When **`trivy config`** reports a **misconfiguration** (check IDs like **`AWS-0104`**, **`DS-0002`** — not CVE vulnerability rows from **`trivy fs`** vuln scans):
+
+1. **Prefer fixing** the HCL/Dockerfile (least privilege, encryption, IMDSv2, non-root user, etc.).
+2. If an ignore is required, add **`#trivy:ignore:<id>`** on the line **immediately above** the Terraform resource or Dockerfile instruction, with a **short `#` comment** on the same line or the line above explaining why (narrow scope).
+3. Use **`.trivyignore`** only when inline suppression is not possible — one ID per line with a **`#` justification** above each.
+
 ## Critical module guardrails
 
 - **Breaking changes:** Do **not** change existing variable names or types without a migration plan (refactor-module skill).

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,16 @@
     "schedule": ["at any time"]
   },
   "labels": ["ok-to-test"],
+  "regexManagers": [
+    {
+      "description": "Manage bumping the version of the common bash library",
+      "fileMatch": ["scripts/terraform-docs.sh$"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?VERSION=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
   "packageRules": [
     {
       "description": "Terraform providers and version in the root versions.tf",

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,34 @@
+---
+# Trivy — static IaC misconfiguration for this ROSA Classic Terraform module repo.
+# Used with `trivy config --config trivy.yaml .` and by CodeRabbit when Trivy
+# is enabled (see .coderabbit.yaml). Scans root, modules/**, examples/**, and
+# Dockerfile. Prefer inline `#trivy:ignore:<ID>` on the flagged resource (see
+# AGENTS.md); repo-wide `.trivyignore` only as a last resort.
+#
+# https://trivy.dev/latest/docs/references/configuration/config-file/
+# https://trivy.dev/latest/docs/configuration/filtering/
+# Parser WARNs about missing var values are normal for modules without tfvars.
+
+# Match CodeRabbit chill-style signal; suppress MEDIUM/LOW/UNKNOWN noise.
+severity:
+  - CRITICAL
+  - HIGH
+
+scan:
+  skip-dirs:
+    - "**/.terraform"
+  # No Terraform plan JSON/snapshot inputs; no tfvars (consumer-supplied).
+  skip-files:
+    - "**/*.tfvars"
+    - "**/*.tfvars.json"
+    - "**/*.auto.tfvars"
+    - "**/*.auto.tfvars.json"
+  # IaC misconfiguration only — not vuln DB scans on lockfiles / container SBOM.
+  scanners:
+    - misconfig
+
+misconfiguration:
+  # Static Terraform HCL + root Dockerfile only (no plan-derived scans).
+  scanners:
+    - terraform
+    - dockerfile


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when an item does not apply.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary

Align ROSA Classic module repo automation and PR review tooling with **terraform-rhcs-rosa-hcp**: Renovate (including `regexManagers` for `scripts/terraform-docs.sh`), CodeRabbit (Classic-specific instructions, same tool matrix as HCP), Gitleaks, Trivy config + `.trivyignore`, and an **AGENTS.md** Trivy section so ignore guidance matches the new `trivy.yaml`.

## Detailed Description of the Issue

Classic lagged the HCP module on dependency automation and consistent static analysis in review (CodeRabbit tools, secret scanning, IaC misconfiguration). That made cross-repo standards ([OCM-24298](https://redhat.atlassian.net/browse/OCM-24298)) harder to enforce and could let Mintmaker/Renovate PRs miss terraform-docs script bumps or run without the same review signals as HCP.

## Related Issues and PRs
- Jira: [OCM-24298](https://redhat.atlassian.net/browse/OCM-24298)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new module capability or new user-facing behavior.
- [ ] fix - resolves incorrect module behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting/naming changes with no logic impact.
- [ ] refactor - module code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

No `.coderabbit.yaml`, `.gitleaks.toml`, `trivy.yaml`, or `.trivyignore` on `main`. `renovate.json` matched HCP in most `packageRules` but omitted the HCP `regexManagers` block for `scripts/terraform-docs.sh`. **AGENTS.md** had no Trivy contributor guidance.

## Behavior After This Change

Renovate can bump the terraform-docs script version like HCP. CodeRabbit runs the same tool set (with Classic-oriented `path_instructions`). Gitleaks and Trivy use repo-local config aligned with HCP; **AGENTS.md** documents how to handle Trivy findings and ignores.

## How to Test (Step-by-Step)

### Preconditions
N/A (no runtime module behavior change).

### Test Steps
1. Confirm new files are present: `.coderabbit.yaml`, `.gitleaks.toml`, `trivy.yaml`, `.trivyignore`, updated `renovate.json`, **AGENTS.md** Trivy section.
2. Optionally run `trivy config --config trivy.yaml .` locally if Trivy is installed.
3. Optionally run `gitleaks detect --config .gitleaks.toml --no-git` from repo root.

### Expected Results

Trivy and Gitleaks use the committed configs without parse errors; module Terraform behavior unchanged.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: N/A
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] I checked if this affects terraform-rhcs-rosa-hcp and submitted (or already submitted) a companion PR when needed.
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make verify` passes.
- [ ] `make verify-gen` passes.
- [x] Documentation was added/updated where appropriate (see `make terraform-docs`).
- [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review configuration with repository-wide best practices and quality standards.
  * Enabled automated security scanning for vulnerabilities and infrastructure misconfigurations.
  * Configured secret detection to prevent accidental credential exposure.
  * Added dependency update automation for streamlined maintenance.

* **Documentation**
  * Added guidance for addressing security scan findings and exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->