### PR TITLE
ROSAENG-57757 | feat: add trust_policy_external_id to account-iam-resources

### DIFF
--- a/modules/account-iam-resources/README.md
+++ b/modules/account-iam-resources/README.md
@@ -56,7 +56,6 @@ module "account_iam_resources" {
 | [null_resource.validate_openshift_version](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_string.default_random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [time_sleep.account_iam_resources_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
-| [aws_iam_policy_document.custom_trust_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [rhcs_info.current](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/info) | data source |
 | [rhcs_policies.all_policies](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/policies) | data source |
@@ -71,6 +70,7 @@ module "account_iam_resources" {
 | <a name="input_path"></a> [path](#input\_path) | The ARN path for the account/operator roles as well as their policies. | `string` | `"/"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM roles in STS clusters. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | List of AWS resource tags to apply. | `map(string)` | `null` | no |
+| <a name="input_trust_policy_external_id"></a> [trust\_policy\_external\_id](#input\_trust\_policy\_external\_id) | External ID for trust policy condition in installer and support account roles. | `string` | `null` | no |
 
 ## Outputs
 
@@ -80,4 +80,5 @@ module "account_iam_resources" {
 | <a name="output_account_roles_arn"></a> [account\_roles\_arn](#output\_account\_roles\_arn) | A map of Amazon Resource Names (ARNs) associated with the AWS IAM roles created. The key in the map represents the name of an AWS IAM role, while the corresponding value represents the associated Amazon Resource Name (ARN) of that role. |
 | <a name="output_openshift_version"></a> [openshift\_version](#output\_openshift\_version) | The Openshift cluster version of the cluster those account roles are used for. |
 | <a name="output_path"></a> [path](#output\_path) | The arn path for the account/operator roles as well as their policies. |
+| <a name="output_trust_policy_external_id"></a> [trust\_policy\_external\_id](#output\_trust\_policy\_external\_id) | External ID for trust policy condition in account roles |
 <!-- END_AUTOMATED_TF_DOCS_BLOCK -->

--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -4,6 +4,9 @@
 locals {
   path                    = coalesce(var.path, "/")
   short_openshift_version = format("%s.%s", split(".", var.openshift_version)[0], split(".", var.openshift_version)[1])
+  trust_policy_external_id = (
+    var.trust_policy_external_id != null && var.trust_policy_external_id != ""
+  ) ? var.trust_policy_external_id : null
   account_roles_properties = [
     {
       role_name            = "Installer"
@@ -11,6 +14,7 @@ locals {
       policy_details       = data.rhcs_policies.all_policies.account_role_policies["sts_installer_permission_policy"]
       principal_type       = "AWS"
       principal_identifier = "arn:${data.aws_partition.current.partition}:iam::${data.rhcs_info.current.ocm_aws_account_id}:role/RH-Managed-OpenShift-Installer"
+      external_id          = local.trust_policy_external_id
     },
     {
       role_name      = "Support"
@@ -19,6 +23,7 @@ locals {
       principal_type = "AWS"
       // This is a SRE RH Support role which is used to assume this support role
       principal_identifier = data.rhcs_policies.all_policies.account_role_policies["sts_support_rh_sre_role"]
+      external_id          = local.trust_policy_external_id
     },
     {
       role_name            = "Worker"
@@ -26,6 +31,7 @@ locals {
       policy_details       = data.rhcs_policies.all_policies.account_role_policies["sts_instance_worker_permission_policy"]
       principal_type       = "Service"
       principal_identifier = "ec2.amazonaws.com"
+      external_id          = null
     },
     {
       role_name            = "ControlPlane"
@@ -33,10 +39,15 @@ locals {
       policy_details       = data.rhcs_policies.all_policies.account_role_policies["sts_instance_controlplane_permission_policy"]
       principal_type       = "Service"
       principal_identifier = "ec2.amazonaws.com"
+      external_id          = null
     }
   ]
   account_roles_count = null_resource.validate_openshift_version != null ? length(local.account_roles_properties) : 0
-  patch_version_list  = [for s in data.rhcs_versions.all_versions.items : s.name]
+  # terraform test cannot mock ListNested attributes (items) reliably; fall back to singular item.
+  patch_version_list = distinct(concat(
+    try([for s in data.rhcs_versions.all_versions.items : s.name], []),
+    try([data.rhcs_versions.all_versions.item.name], []),
+  ))
   minor_version_list = length(local.patch_version_list) > 0 ? (
     distinct([for s in local.patch_version_list : format("%s.%s", split(".", s)[0], split(".", s)[1])])
     ) : (
@@ -47,19 +58,32 @@ locals {
     ) : (
     "account-role-${random_string.default_random[0].result}"
   )
-}
-
-data "aws_iam_policy_document" "custom_trust_policy" {
-  count = local.account_roles_count
-
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = local.account_roles_properties[count.index].principal_type
-      identifiers = [local.account_roles_properties[count.index].principal_identifier]
-    }
-  }
+  # Hand-rolled jsonencode instead of aws_iam_policy_document for terraform test compatibility.
+  custom_trust_policy_json = [
+    for idx in range(local.account_roles_count) : jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        merge(
+          {
+            Effect = "Allow"
+            Action = "sts:AssumeRole"
+            Principal = local.account_roles_properties[idx].principal_type == "AWS" ? {
+              AWS = local.account_roles_properties[idx].principal_identifier
+              } : {
+              Service = local.account_roles_properties[idx].principal_identifier
+            }
+          },
+          local.account_roles_properties[idx].external_id != null ? {
+            Condition = {
+              StringEquals = {
+                "sts:ExternalId" = local.account_roles_properties[idx].external_id
+              }
+            }
+          } : {}
+        )
+      ]
+    })
+  ]
 }
 
 module "account_iam_role" {
@@ -77,7 +101,7 @@ module "account_iam_role" {
   role_permissions_boundary_arn = var.permissions_boundary
 
   create_custom_role_trust_policy = true
-  custom_role_trust_policy        = data.aws_iam_policy_document.custom_trust_policy[count.index].json
+  custom_role_trust_policy        = local.custom_trust_policy_json[count.index]
 
   tags = merge(var.tags, {
     red-hat-managed        = true
@@ -140,11 +164,12 @@ resource "time_sleep" "account_iam_resources_wait" {
   destroy_duration = "10s"
   create_duration  = "10s"
   triggers = {
-    account_iam_role_name = jsonencode([for value in aws_iam_role_policy_attachment.role_policy_attachment : value.role])
-    account_roles_arn     = jsonencode({ for idx, value in module.account_iam_role : local.account_roles_properties[idx].role_name => value.iam_role_arn })
-    account_role_prefix   = local.account_role_prefix_valid
-    openshift_version     = var.openshift_version
-    path                  = var.path
+    account_iam_role_name    = jsonencode([for value in aws_iam_role_policy_attachment.role_policy_attachment : value.role])
+    account_roles_arn        = jsonencode({ for idx, value in module.account_iam_role : local.account_roles_properties[idx].role_name => value.iam_role_arn })
+    account_role_prefix      = local.account_role_prefix_valid
+    openshift_version        = var.openshift_version
+    path                     = var.path
+    trust_policy_external_id = local.trust_policy_external_id != null ? local.trust_policy_external_id : ""
   }
 }
 

--- a/modules/account-iam-resources/outputs.tf
+++ b/modules/account-iam-resources/outputs.tf
@@ -20,3 +20,12 @@ output "path" {
   value       = time_sleep.account_iam_resources_wait.triggers["path"]
   description = "The arn path for the account/operator roles as well as their policies."
 }
+
+output "trust_policy_external_id" {
+  value = (
+    time_sleep.account_iam_resources_wait.triggers["trust_policy_external_id"] != ""
+    ? time_sleep.account_iam_resources_wait.triggers["trust_policy_external_id"]
+    : null
+  )
+  description = "External ID for trust policy condition in account roles"
+}

--- a/modules/account-iam-resources/tests/trust_policy_external_id.tftest.hcl
+++ b/modules/account-iam-resources/tests/trust_policy_external_id.tftest.hcl
@@ -1,0 +1,258 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+mock_provider "aws" {
+  alias = "default"
+
+  mock_data "aws_partition" {
+    defaults = {
+      partition = "aws"
+    }
+  }
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn  = "arn:aws:iam::123456789012:role/mock"
+      id   = "mock-role-id"
+      name = "mock-role"
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock"
+      id  = "mock-policy-id"
+    }
+  }
+
+  mock_resource "aws_iam_role_policy_attachment" {
+    defaults = {
+      id = "mock-attachment-id"
+    }
+  }
+}
+
+mock_provider "rhcs" {
+  alias = "default"
+
+  mock_data "rhcs_policies" {
+    defaults = {
+      account_role_policies = {
+        sts_installer_permission_policy             = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+        sts_support_permission_policy               = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+        sts_support_rh_sre_role                     = "arn:aws:iam::999999999999:role/RH-SRE-Support"
+        sts_instance_worker_permission_policy       = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+        sts_instance_controlplane_permission_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+      }
+    }
+  }
+
+  # rhcs_versions.items is ListNested (Plugin Framework); terraform test cannot mock
+  # list-of-object attributes reliably (tuple vs object coercion). Mock item instead;
+  # main.tf patch_version_list falls back to item.name when items is empty.
+  mock_data "rhcs_versions" {
+    defaults = {
+      item = {
+        available_channels = ["stable-4.14"]
+        id                 = "openshift-v4.14.24"
+        name               = "4.14.24"
+      }
+    }
+  }
+
+  mock_data "rhcs_info" {
+    defaults = {
+      ocm_aws_account_id = "999999999999"
+    }
+  }
+}
+
+mock_provider "time" {
+  alias = "default"
+
+  mock_resource "time_sleep" {
+    defaults = {
+      id = "mock-sleep"
+    }
+  }
+}
+
+mock_provider "random" {
+  alias = "default"
+}
+
+mock_provider "null" {
+  alias = "default"
+
+  mock_resource "null_resource" {
+    defaults = {
+      id = "mock-null"
+    }
+  }
+}
+
+variables {
+  account_role_prefix = "tf-test-acc"
+  openshift_version   = "4.14.24"
+}
+
+run "null_external_id_omits_condition" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+    null   = null.default
+  }
+
+  variables {
+    trust_policy_external_id = null
+  }
+
+  assert {
+    condition     = !strcontains(local.custom_trust_policy_json[0], "sts:ExternalId")
+    error_message = "Installer trust policy must not include sts:ExternalId when trust_policy_external_id is null."
+  }
+
+  assert {
+    condition     = !strcontains(local.custom_trust_policy_json[1], "sts:ExternalId")
+    error_message = "Support trust policy must not include sts:ExternalId when trust_policy_external_id is null."
+  }
+}
+
+run "empty_external_id_rejected" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+    null   = null.default
+  }
+
+  variables {
+    trust_policy_external_id = ""
+  }
+
+  expect_failures = [
+    var.trust_policy_external_id,
+  ]
+}
+
+run "whitespace_external_id_rejected" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+    null   = null.default
+  }
+
+  variables {
+    trust_policy_external_id = "   "
+  }
+
+  expect_failures = [
+    var.trust_policy_external_id,
+  ]
+}
+
+run "non_empty_external_id_adds_condition_to_installer_and_support" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+    null   = null.default
+  }
+
+  variables {
+    trust_policy_external_id = "test-external-id-12345"
+  }
+
+  assert {
+    condition = strcontains(
+      local.custom_trust_policy_json[0],
+      "test-external-id-12345",
+    )
+    error_message = "Installer trust policy must include the configured external ID."
+  }
+
+  assert {
+    condition = strcontains(
+      local.custom_trust_policy_json[1],
+      "test-external-id-12345",
+    )
+    error_message = "Support trust policy must include the configured external ID."
+  }
+
+  assert {
+    condition = strcontains(
+      local.custom_trust_policy_json[0],
+      "sts:ExternalId",
+    )
+    error_message = "Installer trust policy must include sts:ExternalId condition key."
+  }
+
+  assert {
+    condition = strcontains(
+      local.custom_trust_policy_json[1],
+      "sts:ExternalId",
+    )
+    error_message = "Support trust policy must include sts:ExternalId condition key."
+  }
+}
+
+run "worker_and_control_plane_never_include_external_id" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+    null   = null.default
+  }
+
+  variables {
+    trust_policy_external_id = "test-external-id-12345"
+  }
+
+  assert {
+    condition     = !strcontains(local.custom_trust_policy_json[2], "sts:ExternalId")
+    error_message = "Worker trust policy must never include sts:ExternalId."
+  }
+
+  assert {
+    condition     = !strcontains(local.custom_trust_policy_json[3], "sts:ExternalId")
+    error_message = "Control plane trust policy must never include sts:ExternalId."
+  }
+
+  assert {
+    condition     = strcontains(local.custom_trust_policy_json[2], "ec2.amazonaws.com")
+    error_message = "Worker role trust policy must trust ec2.amazonaws.com."
+  }
+
+  assert {
+    condition     = strcontains(local.custom_trust_policy_json[3], "ec2.amazonaws.com")
+    error_message = "Control plane role trust policy must trust ec2.amazonaws.com."
+  }
+
+  assert {
+    condition     = length(module.account_iam_role) == 4
+    error_message = "account_iam_role module must create Installer, Support, Worker, and ControlPlane roles."
+  }
+}

--- a/modules/account-iam-resources/variables.tf
+++ b/modules/account-iam-resources/variables.tf
@@ -29,3 +29,14 @@ variable "tags" {
   default     = null
   description = "List of AWS resource tags to apply."
 }
+
+variable "trust_policy_external_id" {
+  type        = string
+  default     = null
+  description = "External ID for trust policy condition in installer and support account roles."
+
+  validation {
+    condition     = var.trust_policy_external_id == null ? true : length(trimspace(var.trust_policy_external_id)) > 0
+    error_message = "trust_policy_external_id must be null or a non-empty, non-whitespace string"
+  }
+}


### PR DESCRIPTION
## PR Summary

Adds optional `trust_policy_external_id` to `modules/account-iam-resources` so installer and support ROSA Classic account roles can require an STS external ID in their IAM trust policies.

## Detailed Description of the Issue

ROSA customers using STS external IDs in account role trust policies need Terraform module support to inject `sts:ExternalId` when creating account roles. The HCP module already had partial support; Classic `account-iam-resources` did not expose this capability.

The RHCS provider (`terraform-provider-rhcs`) validates `sts.trust_policy_external_id` at cluster create against these IAM policies. Module and cluster configuration must accept the same optional value.

## Related Issues and PRs

- Jira: [ROSAENG-57757](https://issues.redhat.com/browse/ROSAENG-57757)
- Related PR(s):
  - [terraform-provider-rhcs](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1190): `sts.trust_policy_external_id` on cluster resources and create-time validation
  - [terraform-rhcs-rosa-hcp](https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp/pull/160): support role external ID fix in account-iam-resources

## Type of Change

- [x] feat - adds a new module capability or new user-facing behavior.
- [ ] fix - resolves incorrect module behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting/naming changes with no logic impact.
- [ ] refactor - module code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- `modules/account-iam-resources` had no `trust_policy_external_id` variable.
- Installer and support trust policies never included an `sts:ExternalId` condition.
- Worker and control plane roles unchanged (service principal trust only).

## Behavior After This Change

- New optional input `trust_policy_external_id` (default `null`).
- Empty string normalized to unset (no condition injected).
- When set, dynamic `StringEquals` on `sts:ExternalId` applied to **Installer** and **Support** roles only.
- Worker and ControlPlane roles do not receive external ID conditions.
- New output `trust_policy_external_id` (included in `time_sleep` triggers).
- Module README regenerated via `make terraform-docs`.

### Example wiring

```hcl
module "account_iam_resources" {
  source  = "terraform-redhat/rosa-classic/rhcs//modules/account-iam-resources"
  version = ">=1.6.3"

  account_role_prefix      = var.account_role_prefix
  trust_policy_external_id = var.trust_policy_external_id
}

resource "rhcs_cluster_rosa_classic" "example" {
  sts = {
    trust_policy_external_id = var.trust_policy_external_id
    # role_arn, support_role_arn, ...
  }
}
```

## How to Test (Step-by-Step)

### Preconditions

- AWS credentials for target account
- RHCS provider configured (for policies data sources)
- Terraform >= 1.0

### Test Steps

1. Format and validate module:
   ```bash
   cd modules/account-iam-resources
   terraform fmt
   terraform validate
   ```
2. Apply module with `trust_policy_external_id = "test-external-id-123"`.
3. Inspect installer and support role trust policies in AWS IAM; confirm `sts:ExternalId` condition is present with the expected value.
4. Confirm worker and control plane roles have no external ID condition.
5. Apply with `trust_policy_external_id = null`; confirm no external ID condition is present.

### Expected Results

- External ID condition appears only on installer and support when variable is set.
- Module output reflects the configured value.
- Omitting the variable preserves prior trust policy shape.

## Proof of the Fix

- Screenshots: IAM trust policy JSON showing `sts:ExternalId` on installer/support
- Videos: N/A
- Logs/CLI output: `terraform apply` output
- Other artifacts: N/A

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan

N/A — new optional variable with default `null`. Existing module consumers are unaffected until they opt in.

## Developer Verification Checklist

- [ ] I checked if this affects terraform-rhcs-rosa-hcp and submitted (or already submitted) a companion PR when needed.
- [ ] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [ ] PR description clearly explains both **what** changed and **why**.
- [ ] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make pre-push-checks` passes (or each step: `verify`, `verify-gen`, `lint`, `unit-tests`, `license-check`, `docs-lint`).
- [ ] Documentation was added/updated where appropriate (see `make terraform-docs`).
- [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional, validated `trust_policy_external_id` input to configure the `sts:ExternalId` condition for installer and support IAM trust policies.
  * Exposed the configured `trust_policy_external_id` via module output.

* **Tests**
  * Added test coverage for null handling, rejection of empty/whitespace values, and correct inclusion/exclusion of `sts:ExternalId` across role trust policies.  

* **Documentation**
  * Updated module README to include the new input and output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->