### PR TITLE
OCM-00000 | ci: fix security-check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
 WORKDIR /app
 COPY . /app
-RUN yum update -y && yum install -y yum-utils shadow-utils unzip tar make git && \
+RUN yum update -y && yum install -y yum-utils shadow-utils unzip tar make git python3-pip && \
     yum clean all && \
     rm -rf /var/cache/yum
 # Prow / integration client image: newest Terraform (TERRAFORM_VERSION). Module minimum compatibility is checked in GitHub Actions verify-min-terraform.yml.

--- a/hack/install-release-tool.sh
+++ b/hack/install-release-tool.sh
@@ -126,32 +126,47 @@ case "$tool" in
     ;;
 
   checkov)
-    # bridgecrewio/checkov GitHub releases do not publish checksum files; verify against
-    # repo-pinned hack/checksums/checkov-<version>.sha256sums instead.
-    case "${os}_${arch}" in
-      linux_amd64) asset="checkov_linux_X86_64.zip" ;;
-      linux_arm64) asset="checkov_linux_arm64.zip" ;;
-      darwin_amd64) asset="checkov_darwin_X86_64.zip" ;;
-      windows_amd64) asset="checkov_windows_X86_64.zip" ;;
-      *)
-        echo "Unsupported platform for checkov: ${os}_${arch}" >&2
-        exit 1
-        ;;
-    esac
-    url="https://github.com/bridgecrewio/checkov/releases/download/${version}/${asset}"
-    checksums_file="${script_dir}/checksums/checkov-${version}.sha256sums"
     dest_bin="${dest_dir}/checkov"
+    # Linux release zips are PyInstaller bundles that require GLIBC >= 2.38; UBI9/RHEL9 (glibc 2.34) cannot run them.
+    if [ "$os" = "linux" ]; then
+      if ! command -v pip3 >/dev/null 2>&1; then
+        echo "pip3 is required to install checkov on Linux (GitHub release zip requires GLIBC >= 2.38)." >&2
+        exit 1
+      fi
+      lib_dir="${dest_dir}/.checkov-lib"
+      rm -rf "$lib_dir"
+      pip3 install --no-cache-dir --target "$lib_dir" "checkov==${version}"
+      cat >"$dest_bin" <<WRAP
+#!/usr/bin/env bash
+export PYTHONPATH="${lib_dir}:\${PYTHONPATH:-}"
+exec python3 -m checkov.main "\$@"
+WRAP
+      chmod +x "$dest_bin"
+    else
+      # bridgecrewio/checkov GitHub releases do not publish checksum files; verify against
+      # repo-pinned hack/checksums/checkov-<version>.sha256sums instead.
+      case "${os}_${arch}" in
+        darwin_amd64) asset="checkov_darwin_X86_64.zip" ;;
+        windows_amd64) asset="checkov_windows_X86_64.zip" ;;
+        *)
+          echo "Unsupported platform for checkov: ${os}_${arch}" >&2
+          exit 1
+          ;;
+      esac
+      url="https://github.com/bridgecrewio/checkov/releases/download/${version}/${asset}"
+      checksums_file="${script_dir}/checksums/checkov-${version}.sha256sums"
 
-    if [ ! -f "${checksums_file}" ]; then
-      echo "Missing pinned checksums: ${checksums_file}" >&2
-      echo "bridgecrewio/checkov releases do not publish upstream checksum files; add SHA256 sums for each platform zip when bumping CHECKOV_VERSION (see CONTRIBUTING.md)." >&2
-      exit 1
+      if [ ! -f "${checksums_file}" ]; then
+        echo "Missing pinned checksums: ${checksums_file}" >&2
+        echo "bridgecrewio/checkov releases do not publish upstream checksum files; add SHA256 sums for each platform zip when bumping CHECKOV_VERSION (see CONTRIBUTING.md)." >&2
+        exit 1
+      fi
+
+      curl -fsSL -o "${tmp}/${asset}" "$url"
+      sha256_verify "${tmp}/${asset}" "${checksums_file}"
+      unzip -o "${tmp}/${asset}" -d "$tmp"
+      install -m 0755 "${tmp}/dist/checkov" "$dest_bin"
     fi
-
-    curl -fsSL -o "${tmp}/${asset}" "$url"
-    sha256_verify "${tmp}/${asset}" "${checksums_file}"
-    unzip -o "${tmp}/${asset}" -d "$tmp"
-    install -m 0755 "${tmp}/dist/checkov" "$dest_bin"
     ;;
 
   gitleaks)


### PR DESCRIPTION
<!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when an item does not apply.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary
  Fix `checkov` installation on UBI9/RHEL9 (glibc 2.34) by installing via `pip3` on Linux instead of using the PyInstaller release zip, which requires glibc ≥ 2.38.

  ## Detailed Description of the Issue
  The checkov GitHub release binaries are PyInstaller bundles that require GLIBC ≥ 2.38. The CI Dockerfile is based on UBI9/RHEL9 (glibc 2.34), so the zip-based install silently fails or errors at runtime. On Linux, `install-release-tool.sh` now installs checkov via `pip3 install
  --target` into a private lib dir and wraps it in a launcher script. The zip-based path is retained for macOS and Windows.

  ## Related Issues and PRs
  - Jira: [OCM-00000](https://jira.url/OCM-00000)
  - Fixes: `#`
  - Related PR(s):
  - Related design/docs:

  ## Type of Change
  <!-- Check the primary type this PR represents -->
  - [ ] feat - adds a new module capability or new user-facing behavior.
  - [ ] fix - resolves incorrect module behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting/naming changes with no logic impact.
  - [ ] refactor - module code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [x] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior
  `install-release-tool.sh checkov` on Linux downloaded the PyInstaller zip from GitHub releases, which requires GLIBC ≥ 2.38 and fails on UBI9/RHEL9. `python3-pip` was not installed in the Dockerfile.

  ## Behavior After This Change
  On Linux, checkov is installed via `pip3` into a private directory (`$dest_dir/.checkov-lib`) and invoked through a wrapper script that sets `PYTHONPATH`. On non-Linux platforms the existing zip-based install path is preserved. The Dockerfile now installs `python3-pip` to satisfy
  the Linux pip3 prerequisite.

  ## How to Test (Step-by-Step)

  ### Preconditions
  - Docker with UBI9/RHEL9-based image build capability.
  - `RHCS_TOKEN` and AWS credentials for full CI runs (N/A for this isolated change).

  ### Test Steps
  1. Build the CI Docker image: `docker build -t rhcs-ci .`
  2. Run inside the container: `docker run --rm rhcs-ci bash -c "/path/to/hack/install-release-tool.sh checkov <version> /usr/local/bin && checkov --version"`
  3. Verify `checkov --version` outputs the expected version without a glibc error.

  ### Expected Results
  `checkov` installs successfully and reports its version on a UBI9/RHEL9 container.

  ## Proof of the Fix
  - Screenshots:
  - Videos:
  - Logs/CLI output:
  - Other artifacts:

  ## Breaking Changes
  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ### Breaking Change Details / Migration Plan

  ## Developer Verification Checklist
  - [ ] **AWS-only changes:** If this PR is mainly **AWS-only** (no `rhcs` resources/variables), I linked **official Red Hat or cited ROSA HCP documentation** that supports reference alignment, or I explained why the change still belongs in-repo per **`Module scope (AWS-only vs core
  HCP)`** in [`.cursor/rules/rosa-hcp-terraform.mdc`](.cursor/rules/rosa-hcp-terraform.mdc).
  - [ ] I checked if this affects terraform-rhcs-rosa-classic and submitted (or already submitted) a companion PR when needed.
  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [ ] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] Tests were added/updated where appropriate.
  - [ ] I manually tested the change.
  - [ ] `make pre-push-checks` passes (or each step: `verify`, `verify-gen`, `lint`, `unit-tests`, `license-check`, `docs-lint`).
  - [ ] Documentation was added/updated where appropriate (see `make terraform-docs`).
  - [ ] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image configuration to include Python 3 package management tools during initial setup.
  * Enhanced checkov installation process with pip-based installation for Linux systems and improved error handling for missing dependencies and checksum files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->