### PR TITLE
ROSAENG-0000 | ci: block major version bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,161 +1,161 @@
 {
-   "$schema":"https://docs.renovatebot.com/renovate-schema.json",
-   "extends":[
-      "config:recommended",
-      "customManagers:dockerfileVersions",
-      ":gitSignOff"
-   ],
-   "dependencyDashboard":true,
-   "minimumReleaseAge":"3 days",
-   "commitMessagePrefix":"OCM-00000 | ci: ",
-   "prConcurrentLimit":2,
-   "prHourlyLimit":0,
-   "reviewersFromCodeOwners":true,
-   "tekton":{
-      "schedule":[
-         "at any time"
-      ]
-   },
-   "labels":[
-      "ok-to-test"
-   ],
-   "customManagers":[
-      {
-         "customType":"regex",
-         "description":"Makefile pre-push-checks CLI tool versions",
-         "managerFilePatterns":[
-            "/Makefile$/"
-         ],
-         "matchStrings":[
-            "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+(?<indent>\\S+)_VERSION \\?= (?<currentValue>\\S+)"
-         ],
-         "versioningTemplate":"semver"
-      },
-      {
-         "customType":"regex",
-         "description":"Dockerfile ARG tool versions",
-         "managerFilePatterns":[
-            "/Dockerfile$/"
-         ],
-         "matchStrings":[
-            "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)\\s"
-         ],
-         "versioningTemplate":"{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-      }
-   ],
-   "packageRules":[
-      {
-         "description":"Makefile CLI tool versions (addlicense, terraform-docs, tflint, vale, checkov, gitleaks)",
-         "matchManagers":[
-            "custom.regex"
-         ],
-         "matchFileNames":[
-            "Makefile"
-         ],
-         "groupName":"Makefile pre-push tools",
-         "groupSlug":"makefile-pre-push-tools",
-         "commitMessagePrefix":"chore(deps): ",
-         "automerge":false
-      },
-      {
-         "description":"CI Dockerfile (UBI base, AWS CLI, ROSA CLI)",
-         "matchManagers":[
-            "custom.regex"
-         ],
-         "matchFileNames":[
-            "Dockerfile"
-         ],
-         "groupName":"CI client image",
-         "groupSlug":"ci-client-image",
-         "commitMessagePrefix":"chore(deps): ",
-         "automerge":false
-      },
-      {
-         "description":"Terraform providers in the root versions.tf",
-         "rangeStrategy":"bump",
-         "matchManagers":[
-            "terraform"
-         ],
-         "matchDepTypes":[
-            "required_provider"
-         ],
-         "matchFileNames":[
-            "versions.tf"
-         ],
-         "groupName":"Terraform Providers",
-         "groupSlug":"tf-providers",
-         "commitMessagePrefix":"chore(deps): ",
-         "automerge":false
-      },
-      {
-         "description":"Do not auto-bump minimum Terraform core (root module required_version); change deliberately (OCM-24461)",
-         "matchManagers":[
-            "terraform"
-         ],
-         "matchDepTypes":[
-            "required_version"
-         ],
-         "matchFileNames":[
-            "versions.tf"
-         ],
-         "enabled":false
-      },
-      {
-         "description":"Terraform providers and version in modules are disabled",
-         "matchManagers":[
-            "terraform"
-         ],
-         "matchDepTypes":[
-            "required_provider",
-            "required_version"
-         ],
-         "matchFileNames":[
-            "modules/**/versions.tf"
-         ],
-         "enabled":false
-      },
-      {
-         "description":"Group GitHub Actions updates to avoid many CI pull requests",
-         "matchManagers":[
-            "github-actions"
-         ],
-         "groupName":"GitHub Actions Dependencies",
-         "groupSlug":"gh-actions",
-         "commitMessagePrefix":"chore(deps): ",
-         "automerge":false
-      },
-      {
-         "description":"Terraform modules grouped by source",
-         "matchManagers":[
-            "terraform"
-         ],
-         "matchDepTypes":[
-            "module"
-         ],
-         "matchFileNames":[
-            "modules/**"
-         ],
-         "groupName":"Terraform Modules",
-         "groupSlug":"tf-modules",
-         "rangeStrategy":"bump",
-         "automerge":false
-      },
-      {
-         "description":"Block major version bumps for specific Terraform modules",
-         "matchManagers":[
-            "terraform"
-         ],
-         "matchDepTypes":[
-            "module"
-         ],
-         "matchPackageNames":[
-            "terraform-aws-modules/iam/aws",
-            "terraform-aws-modules/secrets-manager/aws"
-         ],
-         "matchUpdateTypes":[
-            "major"
-         ],
-         "enabled":false
-      }
-   ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "customManagers:dockerfileVersions",
+    ":gitSignOff"
+  ],
+  "dependencyDashboard": true,
+  "minimumReleaseAge": "3 days",
+  "commitMessagePrefix": "OCM-00000 | ci: ",
+  "prConcurrentLimit": 2,
+  "prHourlyLimit": 0,
+  "reviewersFromCodeOwners": true,
+  "tekton": {
+    "schedule": [
+      "at any time"
+    ]
+  },
+  "labels": [
+    "ok-to-test"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Makefile pre-push-checks CLI tool versions",
+      "managerFilePatterns": [
+        "/Makefile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+(?<indent>\\S+)_VERSION \\?= (?<currentValue>\\S+)"
+      ],
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Dockerfile ARG tool versions",
+      "managerFilePatterns": [
+        "/Dockerfile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Makefile CLI tool versions (addlicense, terraform-docs, tflint, vale, checkov, gitleaks)",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        "Makefile"
+      ],
+      "groupName": "Makefile pre-push tools",
+      "groupSlug": "makefile-pre-push-tools",
+      "commitMessagePrefix": "chore(deps): ",
+      "automerge": false
+    },
+    {
+      "description": "CI Dockerfile (UBI base, AWS CLI, ROSA CLI)",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        "Dockerfile"
+      ],
+      "groupName": "CI client image",
+      "groupSlug": "ci-client-image",
+      "commitMessagePrefix": "chore(deps): ",
+      "automerge": false
+    },
+    {
+      "description": "Terraform providers in the root versions.tf",
+      "rangeStrategy": "bump",
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDepTypes": [
+        "required_provider"
+      ],
+      "matchFileNames": [
+        "versions.tf"
+      ],
+      "groupName": "Terraform Providers",
+      "groupSlug": "tf-providers",
+      "commitMessagePrefix": "chore(deps): ",
+      "automerge": false
+    },
+    {
+      "description": "Do not auto-bump minimum Terraform core (root module required_version); change deliberately (OCM-24461)",
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDepTypes": [
+        "required_version"
+      ],
+      "matchFileNames": [
+        "versions.tf"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Terraform providers and version in modules are disabled",
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDepTypes": [
+        "required_provider",
+        "required_version"
+      ],
+      "matchFileNames": [
+        "modules/**/versions.tf"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Group GitHub Actions updates to avoid many CI pull requests",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions Dependencies",
+      "groupSlug": "gh-actions",
+      "commitMessagePrefix": "chore(deps): ",
+      "automerge": false
+    },
+    {
+      "description": "Terraform modules grouped by source",
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDepTypes": [
+        "module"
+      ],
+      "matchFileNames": [
+        "modules/**"
+      ],
+      "groupName": "Terraform Modules",
+      "groupSlug": "tf-modules",
+      "rangeStrategy": "bump",
+      "automerge": false
+    },
+    {
+      "description": "Block major version bumps for specific Terraform modules",
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDepTypes": [
+        "module"
+      ],
+      "matchPackageNames": [
+        "terraform-aws-modules/iam/aws",
+        "terraform-aws-modules/secrets-manager/aws"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,144 +1,161 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "customManagers:dockerfileVersions",
-    ":gitSignOff"
-  ],
-  "dependencyDashboard": true,
-  "minimumReleaseAge": "3 days",
-  "commitMessagePrefix": "OCM-00000 | ci: ",
-  "prConcurrentLimit": 2,
-  "prHourlyLimit": 0,
-  "reviewersFromCodeOwners": true,
-  "tekton": {
-    "schedule": [
-      "at any time"
-    ]
-  },
-  "labels": [
-    "ok-to-test"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Makefile pre-push-checks CLI tool versions",
-      "managerFilePatterns": [
-        "/Makefile$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+(?<indent>\\S+)_VERSION \\?= (?<currentValue>\\S+)"
-      ],
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Dockerfile ARG tool versions",
-      "managerFilePatterns": [
-        "/Dockerfile$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)\\s"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    }
-  ],
-  "packageRules": [
-    {
-      "description": "Makefile CLI tool versions (addlicense, terraform-docs, tflint, vale, checkov, gitleaks)",
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchFileNames": [
-        "Makefile"
-      ],
-      "groupName": "Makefile pre-push tools",
-      "groupSlug": "makefile-pre-push-tools",
-      "commitMessagePrefix": "chore(deps): ",
-      "automerge": false
-    },
-    {
-      "description": "CI Dockerfile (UBI base, AWS CLI, ROSA CLI)",
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchFileNames": [
-        "Dockerfile"
-      ],
-      "groupName": "CI client image",
-      "groupSlug": "ci-client-image",
-      "commitMessagePrefix": "chore(deps): ",
-      "automerge": false
-    },
-    {
-      "description": "Terraform providers in the root versions.tf",
-      "rangeStrategy": "bump",
-      "matchManagers": [
-        "terraform"
-      ],
-      "matchDepTypes": [
-        "required_provider"
-      ],
-      "matchFileNames": [
-        "versions.tf"
-      ],
-      "groupName": "Terraform Providers",
-      "groupSlug": "tf-providers",
-      "commitMessagePrefix": "chore(deps): ",
-      "automerge": false
-    },
-    {
-      "description": "Do not auto-bump minimum Terraform core (root module required_version); change deliberately (OCM-24461)",
-      "matchManagers": [
-        "terraform"
-      ],
-      "matchDepTypes": [
-        "required_version"
-      ],
-      "matchFileNames": [
-        "versions.tf"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Terraform providers and version in modules are disabled",
-      "matchManagers": [
-        "terraform"
-      ],
-      "matchDepTypes": [
-        "required_provider",
-        "required_version"
-      ],
-      "matchFileNames": [
-        "modules/**/versions.tf"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Group GitHub Actions updates to avoid many CI pull requests",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "groupName": "GitHub Actions Dependencies",
-      "groupSlug": "gh-actions",
-      "commitMessagePrefix": "chore(deps): ",
-      "automerge": false
-    },
-    {
-      "description": "Terraform modules grouped by source",
-      "matchManagers": [
-        "terraform"
-      ],
-      "matchDepTypes": [
-        "module"
-      ],
-      "matchFileNames": [
-        "modules/**"
-      ],
-      "groupName": "Terraform Modules",
-      "groupSlug": "tf-modules",
-      "rangeStrategy": "bump",
-      "automerge": false
-    }
-  ]
+   "$schema":"https://docs.renovatebot.com/renovate-schema.json",
+   "extends":[
+      "config:recommended",
+      "customManagers:dockerfileVersions",
+      ":gitSignOff"
+   ],
+   "dependencyDashboard":true,
+   "minimumReleaseAge":"3 days",
+   "commitMessagePrefix":"OCM-00000 | ci: ",
+   "prConcurrentLimit":2,
+   "prHourlyLimit":0,
+   "reviewersFromCodeOwners":true,
+   "tekton":{
+      "schedule":[
+         "at any time"
+      ]
+   },
+   "labels":[
+      "ok-to-test"
+   ],
+   "customManagers":[
+      {
+         "customType":"regex",
+         "description":"Makefile pre-push-checks CLI tool versions",
+         "managerFilePatterns":[
+            "/Makefile$/"
+         ],
+         "matchStrings":[
+            "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+(?<indent>\\S+)_VERSION \\?= (?<currentValue>\\S+)"
+         ],
+         "versioningTemplate":"semver"
+      },
+      {
+         "customType":"regex",
+         "description":"Dockerfile ARG tool versions",
+         "managerFilePatterns":[
+            "/Dockerfile$/"
+         ],
+         "matchStrings":[
+            "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)\\s"
+         ],
+         "versioningTemplate":"{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      }
+   ],
+   "packageRules":[
+      {
+         "description":"Makefile CLI tool versions (addlicense, terraform-docs, tflint, vale, checkov, gitleaks)",
+         "matchManagers":[
+            "custom.regex"
+         ],
+         "matchFileNames":[
+            "Makefile"
+         ],
+         "groupName":"Makefile pre-push tools",
+         "groupSlug":"makefile-pre-push-tools",
+         "commitMessagePrefix":"chore(deps): ",
+         "automerge":false
+      },
+      {
+         "description":"CI Dockerfile (UBI base, AWS CLI, ROSA CLI)",
+         "matchManagers":[
+            "custom.regex"
+         ],
+         "matchFileNames":[
+            "Dockerfile"
+         ],
+         "groupName":"CI client image",
+         "groupSlug":"ci-client-image",
+         "commitMessagePrefix":"chore(deps): ",
+         "automerge":false
+      },
+      {
+         "description":"Terraform providers in the root versions.tf",
+         "rangeStrategy":"bump",
+         "matchManagers":[
+            "terraform"
+         ],
+         "matchDepTypes":[
+            "required_provider"
+         ],
+         "matchFileNames":[
+            "versions.tf"
+         ],
+         "groupName":"Terraform Providers",
+         "groupSlug":"tf-providers",
+         "commitMessagePrefix":"chore(deps): ",
+         "automerge":false
+      },
+      {
+         "description":"Do not auto-bump minimum Terraform core (root module required_version); change deliberately (OCM-24461)",
+         "matchManagers":[
+            "terraform"
+         ],
+         "matchDepTypes":[
+            "required_version"
+         ],
+         "matchFileNames":[
+            "versions.tf"
+         ],
+         "enabled":false
+      },
+      {
+         "description":"Terraform providers and version in modules are disabled",
+         "matchManagers":[
+            "terraform"
+         ],
+         "matchDepTypes":[
+            "required_provider",
+            "required_version"
+         ],
+         "matchFileNames":[
+            "modules/**/versions.tf"
+         ],
+         "enabled":false
+      },
+      {
+         "description":"Group GitHub Actions updates to avoid many CI pull requests",
+         "matchManagers":[
+            "github-actions"
+         ],
+         "groupName":"GitHub Actions Dependencies",
+         "groupSlug":"gh-actions",
+         "commitMessagePrefix":"chore(deps): ",
+         "automerge":false
+      },
+      {
+         "description":"Terraform modules grouped by source",
+         "matchManagers":[
+            "terraform"
+         ],
+         "matchDepTypes":[
+            "module"
+         ],
+         "matchFileNames":[
+            "modules/**"
+         ],
+         "groupName":"Terraform Modules",
+         "groupSlug":"tf-modules",
+         "rangeStrategy":"bump",
+         "automerge":false
+      },
+      {
+         "description":"Block major version bumps for specific Terraform modules",
+         "matchManagers":[
+            "terraform"
+         ],
+         "matchDepTypes":[
+            "module"
+         ],
+         "matchPackageNames":[
+            "terraform-aws-modules/iam/aws",
+            "terraform-aws-modules/secrets-manager/aws"
+         ],
+         "matchUpdateTypes":[
+            "major"
+         ],
+         "enabled":false
+      }
+   ]
 }


### PR DESCRIPTION
<!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when an item does not apply.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary
  <!-- Briefly describe the most important changes and outcomes (1-2 lines). -->
  Adds a Renovate rule to block major version bumps for `terraform-aws-modules/iam/aws` and `terraform-aws-modules/secrets-manager/aws`, preventing Renovate from proposing breaking upgrades until those modules are replaced with raw resources.

  ## Detailed Description of the Issue
  <!-- Describe the root problem, scope, impact, and user/business context for this Terraform module and its consumers. -->
  Recent major releases of the `iam` and `secrets-manager` community Terraform modules introduced breaking changes. Until this module migrates from those community modules to raw AWS resources (as already done in ROSA HCP), major version bumps must be suppressed to avoid unintended
  breakage for consumers.

  ## Related Issues and PRs
  <!-- Link all tracking items and related code changes -->
  - Jira: [ROSAENG-0000](https://issues.redhat.com/browse/ROSAENG-0000)
  - Fixes: `#`
  - Related PR(s):
  - Related design/docs:

  ## Type of Change
  <!-- Check the primary type this PR represents -->
  - [ ] feat - adds a new module capability or new user-facing behavior.
  - [ ] fix - resolves incorrect module behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting/naming changes with no logic impact.
  - [ ] refactor - module code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [x] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior
  <!-- Describe how the module behaved before this change. -->
  Renovate could open PRs proposing major version upgrades for `terraform-aws-modules/iam/aws` and `terraform-aws-modules/secrets-manager/aws`, which could introduce breaking changes for module consumers.

  ## Behavior After This Change
  <!-- Describe module behavior after this change (user-visible and non-user-visible). -->
  Renovate will skip major version bumps for `terraform-aws-modules/iam/aws` and `terraform-aws-modules/secrets-manager/aws`. Minor and patch updates remain enabled. No change to module behavior at plan/apply time.

  ## How to Test (Step-by-Step)
  <!-- Provide reproducible validation instructions for module maintainers/reviewers -->

  ### Preconditions
  <!-- Required setup: Terraform version, credentials, env vars (e.g. RHCS_TOKEN/AWS creds), provider versions, test data, etc. -->
  N/A — CI configuration change only.

  ### Test Steps
  1. Verify the new `packageRule` entry in `renovate.json` targets `matchPackageNames` for both modules and sets `matchUpdateTypes: ["major"]` with `"enabled": false`.
  2. (Optional) Trigger a Renovate dry-run and confirm no major-version PRs are proposed for the two modules.

  ### Expected Results
  <!-- What should happen after running the steps above -->
  Renovate does not open PRs for major upgrades of `terraform-aws-modules/iam/aws` or `terraform-aws-modules/secrets-manager/aws`.

  ## Proof of the Fix
  <!-- Attach evidence that demonstrates the changed behavior -->
  - Screenshots:
  - Videos:
  - Logs/CLI output:
  - Other artifacts:

  ## Breaking Changes
  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ### Breaking Change Details / Migration Plan
  <!-- Required only when breaking changes are introduced.
  Examples: variable rename/removal, output rename/removal, default value change, resource behavior changes, provider/version requirement changes. -->

  ## Developer Verification Checklist
  - [ ] I checked if this affects terraform-rhcs-rosa-hcp and submitted (or already submitted) a companion PR when needed.
  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [ ] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] Tests were added/updated where appropriate.
  - [ ] I manually tested the change.
  - [ ] `make pre-push-checks` passes (or each step: `verify`, `verify-gen`, `lint`, `unit-tests`, `license-check`, `docs-lint`).
  - [ ] Documentation was added/updated where appropriate (see `make terraform-docs`).
  - [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to prevent major version bumps for selected Terraform modules, reducing unnecessary breaking changes in infrastructure code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->